### PR TITLE
Fix Windows Defender false positive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           $version = python -c "import PyInstaller; print(PyInstaller.__version__)"
           git clone --depth 1 --branch "v$version" https://github.com/pyinstaller/pyinstaller.git _pyinstaller_src
           cd _pyinstaller_src/bootloader
+          (Get-Content src\pyi_utils.c) -replace 'PyInstaller', 'TgWsProxy' | Set-Content src\pyi_utils.c
           python ./waf all --target-arch=64bit
           $dest = python -c "import PyInstaller; import os; print(os.path.join(os.path.dirname(PyInstaller.__file__), 'bootloader', 'Windows-64bit-intel'))"
           New-Item -ItemType Directory -Force -Path $dest
@@ -63,6 +64,7 @@ jobs:
           git clone --depth 1 --branch "v$version" https://github.com/pyinstaller/pyinstaller.git _pyinstaller_src
           cd _pyinstaller_src/bootloader
           $env:CFLAGS = "-Wno-error=old-style-definition -std=c11"
+          (Get-Content src\pyi_utils.c) -replace 'PyInstaller', 'TgWsProxy' | Set-Content src\pyi_utils.c
           python ./waf all --target-arch=64bit
           $dest = python -c "import PyInstaller; import os; print(os.path.join(os.path.dirname(PyInstaller.__file__), 'bootloader', 'Windows-64bit-intel'))"
           New-Item -ItemType Directory -Force -Path $dest


### PR DESCRIPTION
Rebuilding the PyInstaller bootloader from source in GitHub Actions and replacing default signatures (`PyInstaller` strings) with custom ones.

This should help bypass heuristic false positives (like `Wacatac.B!ml`). I'm not entirely sure how effective this will be in the long run (Defender's ML might just need more time to analyze the new file), but here is the current [VirusTotal result](https://www.virustotal.com/gui/file/de946acea4634caea31dde4071635c345aece5f18f75a0b07d480691409ad92a/detection).

I haven't changed the _MEI temp folder prefix, as it might break the unpacking logic. However, it's definitely an option we can explore 