### PR TITLE
[macOS] fix menubar icon

### DIFF
--- a/macos.py
+++ b/macos.py
@@ -552,7 +552,7 @@ class TgWsProxyApp(_TgWsProxyAppBase):
         super().__init__(
             "TG WS Proxy",
             icon=icon_path,
-            template=True,
+            template=False,
             quit_button="Выход",
             menu=[
                 self._open_tg_item,


### PR DESCRIPTION
фикс иконки в менюбаре, когда `Template=True`, иконка полностью черная/белая, если `False` то иконка такая какая была задумана билдом
<img width="56" height="39" alt="image" src="https://github.com/user-attachments/assets/cf66501d-ba30-41fe-8f4b-00a11373f079" />
