### PR TITLE
Docker image for headless proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY requirements-docker.txt ./requirements-docker.txt
-RUN "$VIRTUAL_ENV/bin/pip" install -r requirements-docker.txt
+RUN "$VIRTUAL_ENV/bin/pip" install cryptography==46.0.5
 
 FROM python:3.12-slim AS runtime
 

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,4 +1,0 @@
-# Minimal runtime dependencies for the headless proxy.
-# The main requirements.txt also includes Windows GUI/tray packages
-# that are not needed in containers.
-cryptography==46.0.5


### PR DESCRIPTION
This pull request introduces support for running the project in a Docker container, making it easier to deploy and run the application in isolated environments. The main changes include adding a production-ready `Dockerfile`, a minimal requirements file for Docker, and a `.dockerignore` to optimize build context and image size.

**Docker support and deployment:**

* Added a `Dockerfile` that builds a minimal, production-ready container image for the headless proxy, including multi-stage builds for smaller images and secure defaults.
* Introduced a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, reducing image size and build time.
* Added a `requirements-docker.txt` file specifying only the minimal runtime dependencies needed for the proxy in a container environment.