### PR TITLE
Исправление зависания "Обновления..." на iOS/iPadOS

### DIFF
--- a/proxy/tg_ws_proxy.py
+++ b/proxy/tg_ws_proxy.py
@@ -965,7 +965,6 @@ async def _handle_client(reader, writer):
         if dc is None and dst in _IP_TO_DC:
             dc, is_media = _IP_TO_DC.get(dst)
             if dc in _dc_opt:
-                # FIX: Negative DC for media connections, so the WS pool can distinguish them and use the correct domains.
                 init = _patch_init_dc(init, -dc if is_media else dc)
                 init_patched = True
 
@@ -1069,14 +1068,13 @@ async def _handle_client(reader, writer):
 
         splitter = None
 
-        # Fix: Let the Splitter be As Is turned off for the main PC stream (as Flowseal asked in PR #415),
-        # but STRICTLY turning it On for media-connections (is_media), so as the big files don't get fragmented by the TCP socket.
+        # Turning splitter on for mobile clients or media-connections, so as the big files don't get fragmented by the TCP socket.
         if proto is not None and (init_patched or is_media or proto != _PROTO_INTERMEDIATE):
             try:
                 splitter = _MsgSplitter(init, proto)
                 log.debug("[%s] MsgSplitter activated for proto 0x%08X", label, proto)
             except Exception:
-                 pass
+                pass
 
         # Send the buffered init packet
         await ws.send(init)


### PR DESCRIPTION
## Что изменено

- исправлена обработка MTProto-пакетов при передаче через WebSocket
- добавлено корректное разделение нескольких пакетов, если клиент отправляет их одним TCP-запросом
- добавлена буферизация неполных пакетов, чтобы они не улетали в WebSocket в битом виде
- учтены разные варианты MTProto transport: abridged, intermediate и padded intermediate
- добавлен flush хвоста при закрытии соединения
- на Windows убран лишний шумный ERROR для WinError 1236, который в этом случае не является критичной ошибкой, просто попало в логи при остановке

## В чём была проблема

На iPhone и iPad прокси подключался, но дальше Telegram просто висит на "Обновлении...", без синхронизации сообщений и без загрузки медиа.

Причина была в том, что текущая логика разделения MTProto-пакетов срабатывает некорректно. Если мобильный клиент отправлял несколько пакетов подряд одним куском или если пакет приходил по частям, прокси мог передать их в WebSocket неправильно.
На ПК и Android этого поведения не вижу, а вот на iOS/iPadOS не происходит даже синхронизации сообщений, не то что подгрузки медиа.

## Что получилось в результате

После правки трафик с iOS/iPadOS в локальной сети начал проходить нормально. По логам вижу, что:
- соединения до DC2 и media DC открываются штатно
- через WebSocket идут нормальные сессии с реальным трафиком, в том числе с медиа
- ошибок WebSocket в успешном прогоне нет

При этом существующая работа на ПК и Android не затронута: логика осталась совместимой, просто стала корректнее обрабатывать мобильный трафик.

## Как проверялось

- запуск прокси на Windows в локальной сети
- проверка работы с нескольких устройств (ПК, смартфоны Android и iPhone, планшет iPad)
- просмотр логов реального прогона
- `python -m py_compile proxy/tg_ws_proxy.py`
- локальный smoke-test на разрезанные и склеенные MTProto-пакеты

Изменения продумывались и вносились с участием Codex.
Референс: #414