### PR TITLE
Изменение README для AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ makepkg -si
 # При помощи AUR-helper
 paru -S tg-ws-proxy-bin
 
-# Если вы установили -cli пакет, то запуск осуществляется через systemctl, где 8888 это номер порта и через ":" secret, который можно сгенерировать командой: openssl rand -hex 16
+# Если вы установили -cli пакет, то запуск осуществляется через systemctl, где 8888 это номер порта,
+# разделитель ":" и secret, который можно сгенерировать командой: openssl rand -hex 16
 sudo systemctl start tg-ws-proxy-cli@8888:3075abe65830f0325116bb0416cadf9f
 ```
 


### PR DESCRIPTION
Так как утилита переехала с SOCKS5 на MTPROTO, необходимо добавить в README новые данные для AUR пакета, а именно -cli