### PR TITLE
docker: entrypoint script and CRLF-safe build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/entrypoint.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,12 @@ WORKDIR /app
 COPY --from=builder /opt/venv /opt/venv
 COPY proxy ./proxy
 COPY README.md LICENSE ./
+COPY docker/entrypoint.sh ./docker/entrypoint.sh
+RUN sed -i 's/\r$//' ./docker/entrypoint.sh && chmod +x ./docker/entrypoint.sh
 
 USER app
 
 EXPOSE 1443/tcp
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/bin/sh", "-lc", "set -eu; args=\"--host ${TG_WS_PROXY_HOST} --port ${TG_WS_PROXY_PORT}\"; for dc in ${TG_WS_PROXY_DC_IPS}; do args=\"$args --dc-ip $dc\"; done; exec python -u proxy/tg_ws_proxy.py $args \"$@\"", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/docker/entrypoint.sh"]
 CMD []

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+args="--host ${TG_WS_PROXY_HOST} --port ${TG_WS_PROXY_PORT}"
+for dc in ${TG_WS_PROXY_DC_IPS}; do
+  args="$args --dc-ip $dc"
+done
+exec python -u proxy/tg_ws_proxy.py $args "$@"


### PR DESCRIPTION
Вынес инлайн-команду из `ENTRYPOINT` в отдельный скрипт `docker/entrypoint.sh`. Так надёжнее: не нужно мучиться с экранированием кавычек и копипастой (https://github.com/Flowseal/tg-ws-proxy/issues/490#issuecomment-4154668985). Добавил запуск sed прямо в образе, чтобы срезать символы `CR`