### PR TITLE
Fix/ws fragmented recv

### DIFF
--- a/packaging/linux.spec
+++ b/packaging/linux.spec
@@ -10,7 +10,13 @@ block_cipher = None
 
 # customtkinter ships JSON themes + assets that must be bundled
 import customtkinter
+import setuptools
+
 ctk_path = os.path.dirname(customtkinter.__file__)
+_vendor = os.path.join(os.path.dirname(setuptools.__file__), '_vendor')
+_setuptools_vendor = (
+    [(_vendor, os.path.join('setuptools', '_vendor'))]
+    if os.path.isdir(_vendor) else [])
 
 # Collect gi (PyGObject) submodules and data so pystray._appindicator works
 gi_hiddenimports = collect_submodules('gi')
@@ -26,7 +32,7 @@ a = Analysis(
     [os.path.join(os.path.dirname(SPEC), os.pardir, 'linux.py')],
     pathex=[],
     binaries=[],
-    datas=[(ctk_path, 'customtkinter/')] + gi_datas + typelib_datas,
+    datas=[(ctk_path, 'customtkinter/')] + _setuptools_vendor + gi_datas + typelib_datas,
     hiddenimports=[
         'pystray._appindicator',
         'PIL._tkinter_finder',
@@ -35,6 +41,7 @@ a = Analysis(
         'cryptography.hazmat.primitives.ciphers.algorithms',
         'cryptography.hazmat.primitives.ciphers.modes',
         'cryptography.hazmat.backends.openssl',
+        'platformdirs',
         'gi',
         '_gi',
         'gi.repository.GLib',

--- a/packaging/macos.spec
+++ b/packaging/macos.spec
@@ -5,11 +5,18 @@ import os
 
 block_cipher = None
 
+import setuptools
+
+_vendor = os.path.join(os.path.dirname(setuptools.__file__), '_vendor')
+_macos_datas = (
+    [(_vendor, os.path.join('setuptools', '_vendor'))]
+    if os.path.isdir(_vendor) else [])
+
 a = Analysis(
     [os.path.join(os.path.dirname(SPEC), os.pardir, 'macos.py')],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=_macos_datas,
     hiddenimports=[
         'rumps',
         'objc',
@@ -21,6 +28,7 @@ a = Analysis(
         'cryptography.hazmat.primitives.ciphers.algorithms',
         'cryptography.hazmat.primitives.ciphers.modes',
         'cryptography.hazmat.backends.openssl',
+        'platformdirs',
     ],
     hookspath=[],
     hooksconfig={},

--- a/packaging/windows.spec
+++ b/packaging/windows.spec
@@ -7,13 +7,21 @@ block_cipher = None
 
 # customtkinter ships JSON themes + assets that must be bundled
 import customtkinter
+import setuptools
+
 ctk_path = os.path.dirname(customtkinter.__file__)
+# pkg_resources (pyi_rth_pkgres) prepends setuptools/_vendor to sys.path and
+# imports jaraco.* from there; frozen builds need the tree on disk.
+_vendor = os.path.join(os.path.dirname(setuptools.__file__), '_vendor')
+_bundle_datas = [(ctk_path, 'customtkinter/')]
+if os.path.isdir(_vendor):
+    _bundle_datas.append((_vendor, os.path.join('setuptools', '_vendor')))
 
 a = Analysis(
     [os.path.join(os.path.dirname(SPEC), os.pardir, 'windows.py')],
     pathex=[],
     binaries=[],
-    datas=[(ctk_path, 'customtkinter/')],
+    datas=_bundle_datas,
     hiddenimports=[
         'pystray._win32',
         'PIL._tkinter_finder',
@@ -22,6 +30,7 @@ a = Analysis(
         'cryptography.hazmat.primitives.ciphers.algorithms',
         'cryptography.hazmat.primitives.ciphers.modes',
         'cryptography.hazmat.backends.openssl',
+        'platformdirs',
     ],
     hookspath=[],
     hooksconfig={},

--- a/proxy/tg_ws_proxy.py
+++ b/proxy/tg_ws_proxy.py
@@ -234,8 +234,15 @@ class RawWebSocket:
         await self.writer.drain()
 
     async def recv(self) -> Optional[bytes]:
+        """
+        Return one complete WebSocket data message (RFC 6455), reassembling
+        fragmented BINARY/TEXT frames. Control frames may appear between
+        fragments and are handled without breaking reassembly.
+        """
+        fragments: Optional[List[bytes]] = None
+
         while not self._closed:
-            opcode, payload = await self._read_frame()
+            opcode, payload, fin = await self._read_frame()
 
             if opcode == self.OP_CLOSE:
                 self._closed = True
@@ -260,8 +267,38 @@ class RawWebSocket:
             if opcode == self.OP_PONG:
                 continue
 
+            # Continuation — only valid inside a fragmented message
+            if opcode == 0:
+                if fragments is None:
+                    self._closed = True
+                    try:
+                        self.writer.close()
+                        await self.writer.wait_closed()
+                    except Exception:
+                        pass
+                    return None
+                fragments.append(payload)
+                if fin:
+                    out = b''.join(fragments)
+                    fragments = None
+                    return out
+                continue
+
             if opcode in (0x1, 0x2):
-                return payload
+                if fragments is not None:
+                    self._closed = True
+                    try:
+                        self.writer.close()
+                        await self.writer.wait_closed()
+                    except Exception:
+                        pass
+                    return None
+                if fin:
+                    return payload
+                fragments = [payload]
+                continue
+
+            # Reserved / unknown data opcodes — skip frame, keep reading
             continue
         return None
 
@@ -300,8 +337,9 @@ class RawWebSocket:
             return _st_BBH4s.pack(fb, 0x80 | 126, length, mask_key) + masked
         return _st_BBQ4s.pack(fb, 0x80 | 127, length, mask_key) + masked
 
-    async def _read_frame(self) -> Tuple[int, bytes]:
+    async def _read_frame(self) -> Tuple[int, bytes, bool]:
         hdr = await self.reader.readexactly(2)
+        fin = bool(hdr[0] & 0x80)
         opcode = hdr[0] & 0x0F
         length = hdr[1] & 0x7F
         if length == 126:
@@ -311,9 +349,9 @@ class RawWebSocket:
         if hdr[1] & 0x80:
             mask_key = await self.reader.readexactly(4)
             payload = await self.reader.readexactly(length)
-            return opcode, _xor_mask(payload, mask_key)
+            return opcode, _xor_mask(payload, mask_key), fin
         payload = await self.reader.readexactly(length)
-        return opcode, payload
+        return opcode, payload, fin
 
 
 def _human_bytes(n: int) -> str:


### PR DESCRIPTION
Русский
1. Прокси: фрагментированные WebSocket-сообщения (proxy/tg_ws_proxy.py)
_read_frame теперь возвращает флаг FIN вместе с opcode и payload.
recv() собирает одно целое BINARY/TEXT-сообщение по RFC 6455: если первый фрейм с FIN=0, следующие кадры с opcode continuation (0) склеиваются до фрейма с FIN=1.
PING/PONG по-прежнему обрабатываются между фрагментами и не ломают сборку.
При нарушении порядка фреймов (continuation без начала или новый data-фрейм до конца предыдущего сообщения) соединение закрывается и возвращается None.
Зачем: раньше отдавался только первый фрейм, остальные отбрасывались — ломался MTProto-поток и часть медиа (крупные файлы, превью и т.д.) могла не загружаться, если сервер шлёт фрагментированные WS-кадры.

2. Сборка: PyInstaller и pkg_resources / jaraco (packaging/*.spec)
В datas добавлена рекурсивная упаковка каталога setuptools/_vendor в setuptools/_vendor внутри бандла.
В hiddenimports добавлен platformdirs.
Зачем: в setuptools 80+ pkg_resources дописывает setuptools/_vendor в sys.path и импортирует jaraco.* и platformdirs. В onefile без этого каталога на диске при старте падало: ModuleNotFoundError: No module named 'jaraco' (runtime hook pyi_rth_pkgres).

Изменения внесены в windows, linux и macos spec-файлы.

English
1. Proxy: fragmented WebSocket messages (proxy/tg_ws_proxy.py)
_read_frame now returns a FIN flag along with opcode and payload.
recv() reassembles one logical BINARY/TEXT message per RFC 6455: if the first frame has FIN=0, subsequent continuation (opcode 0) frames are concatenated until a frame with FIN=1.
PING/PONG are still handled between fragments without breaking reassembly.
On protocol violations (continuation without a start, or a new data frame before the previous message ends), the connection is closed and None is returned.
Why: Previously only the first frame was returned and the rest were dropped, which corrupted the MTProto byte stream and could break some media downloads when the server sends fragmented WebSocket frames.

2. Packaging: PyInstaller vs pkg_resources / jaraco (packaging/*.spec)
datas: recursively bundle setuptools/_vendor into setuptools/_vendor inside the frozen app.
hiddenimports: add platformdirs.
Why: Setuptools 80+ pkg_resources prepends setuptools/_vendor to sys.path and imports jaraco.* and platformdirs. One-file builds did not ship that tree on disk, so startup failed with ModuleNotFoundError: No module named 'jaraco' (via pyi_rth_pkgres).

Applied to Windows, Linux, and macOS spec files.