### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -280,7 +280,7 @@ Tray-приложение хранит данные в:
 
 ## Автоматическая сборка
 
-Проект содержит спецификации PyInstaller ([`packaging/windows.spec`](packaging/windows.spec), [`packaging/macos.spec`](packaging/macos.spec), [`packaging/linux.spec`](packaging/linux.spec)) и GitHub Actions workflow ([`.github/workflows/build.yml`](.github/workflows/build.yml)) для автоматической сборки.
+Проект содержит спецификации PyInstaller ([`packaging/windows.spec`](../packaging/windows.spec), [`packaging/macos.spec`](../packaging/macos.spec), [`packaging/linux.spec`](../packaging/linux.spec)) и GitHub Actions workflow ([`.github/workflows/build.yml`](../.github/workflows/build.yml)) для автоматической сборки.
 
 Минимально поддерживаемые версии ОС для текущих бинарных сборок:
 


### PR DESCRIPTION
Fix relative links
Поскольку readme.md лежит в директории docs, относительные ссылки 
```
packaging/macos.spec
packaging/windows.spec
.github/workflows/build.yml
```
сломаны и ведут 
```
docs/packaging/macos.spec
docs/packaging/windows.spec
docs/.github/workflows/build.yml
```
соответственно.