### PR TITLE
support TG_WS_PROXY_SECRET

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PATH=/opt/venv/bin:$PATH \
     TG_WS_PROXY_HOST=0.0.0.0 \
     TG_WS_PROXY_PORT=1443 \
+    TG_WS_PROXY_SECRET=""  \
     TG_WS_PROXY_DC_IPS="2:149.154.167.220 4:149.154.167.220"
 
 RUN apt-get update \
@@ -41,5 +42,5 @@ USER app
 
 EXPOSE 1443/tcp
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/bin/sh", "-lc", "set -eu; args=\"--host ${TG_WS_PROXY_HOST} --port ${TG_WS_PROXY_PORT}\"; for dc in ${TG_WS_PROXY_DC_IPS}; do args=\"$args --dc-ip $dc\"; done; exec /opt/venv/bin/python -u proxy/tg_ws_proxy.py $args \"$@\"", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/bin/sh", "-lc", "set -eu; args=\"--host ${TG_WS_PROXY_HOST} --port ${TG_WS_PROXY_PORT}\"; for dc in ${TG_WS_PROXY_DC_IPS}; do args=\"$args --dc-ip $dc\"; done; if [ -n \"${TG_WS_PROXY_SECRET}\" ]; then args=\"$args --secret ${TG_WS_PROXY_SECRET}\"; fi; exec /opt/venv/bin/python -u proxy/tg_ws_proxy.py $args \"$@\"", "--"]
 CMD []


### PR DESCRIPTION
 Добавлена поддержка переменной окружения TG_WS_PROXY_SECRET в Dockerfile
При передаче переменной - прокси запускается с указанным секретом
Если переменная пустая или не задана - секрет генерируется автоматически (исходное поведение)

Позволяет задавать фиксированный секрет при запуске контейнера через Docker/docker-compose, чтобы ссылка для подключения не менялась при перезапуске.