### PR TITLE
Мелкие фиксы настроек и пара багов

### DIFF
--- a/linux.py
+++ b/linux.py
@@ -173,7 +173,9 @@ def _edit_config_dialog() -> None:
                 messagebox.showerror("TG WS Proxy — Ошибка", merged, parent=root)
                 return
 
+            _ui_only_keys = {"appearance", "check_updates"}
             config_changed = any(merged.get(k) != cfg.get(k) for k in merged)
+            proxy_changed = any(merged.get(k) != cfg.get(k) for k in merged if k not in _ui_only_keys)
 
             if not config_changed:
                 _finish()
@@ -183,6 +185,10 @@ def _edit_config_dialog() -> None:
             _config.update(merged)
             log.info("Config saved: %s", merged)
             _tray_icon.menu = _build_menu()
+
+            if not proxy_changed:
+                _finish()
+                return
 
             do_restart = messagebox.askyesno(
                 "Перезапустить?",

--- a/linux.py
+++ b/linux.py
@@ -156,9 +156,15 @@ def _edit_config_dialog() -> None:
         scroll, footer = tray_settings_scroll_and_footer(ctk, frame, theme)
         widgets = install_tray_config_form(ctk, scroll, theme, cfg, DEFAULT_CONFIG, show_autostart=False)
 
+        _original_appearance = ctk.get_appearance_mode()
+
         def _finish() -> None:
             root.destroy()
             done.set()
+
+        def _cancel() -> None:
+            ctk.set_appearance_mode(_original_appearance)
+            _finish()
 
         def on_save() -> None:
             from tkinter import messagebox
@@ -166,6 +172,13 @@ def _edit_config_dialog() -> None:
             if isinstance(merged, str):
                 messagebox.showerror("TG WS Proxy — Ошибка", merged, parent=root)
                 return
+
+            config_changed = any(merged.get(k) != cfg.get(k) for k in merged)
+
+            if not config_changed:
+                _finish()
+                return
+
             save_config(merged)
             _config.update(merged)
             log.info("Config saved: %s", merged)
@@ -180,8 +193,8 @@ def _edit_config_dialog() -> None:
             if do_restart:
                 threading.Thread(target=lambda: restart_proxy(_config, _show_error), daemon=True).start()
 
-        root.protocol("WM_DELETE_WINDOW", _finish)
-        install_tray_config_buttons(ctk, footer, theme, on_save=on_save, on_cancel=_finish)
+        root.protocol("WM_DELETE_WINDOW", _cancel)
+        install_tray_config_buttons(ctk, footer, theme, on_save=on_save, on_cancel=_cancel)
 
     ctk_run_dialog(_build)
 

--- a/ui/ctk_tray_ui.py
+++ b/ui/ctk_tray_ui.py
@@ -330,6 +330,7 @@ def install_tray_config_form(
     def _on_appearance_change(choice: str) -> None:
         cfg_val = _APPEARANCE_TO_CFG.get(choice, "auto")
         ctk.set_appearance_mode(_APPEARANCE_TO_CTK[cfg_val])
+        cfg["appearance"] = cfg_val
 
     ctk.CTkComboBox(
         header,
@@ -444,17 +445,27 @@ def install_tray_config_form(
         import threading as _threading
         if user_domain:
             def _worker():
-                res = _run_cfproxy_connectivity_test(user_domain)
-                if btn:
-                    btn.after(0, lambda: btn.configure(text="Тест", state="normal"))
-                    btn.after(0, lambda: _cfproxy_show_test_results(user_domain, res))
+                try:
+                    res = _run_cfproxy_connectivity_test(user_domain)
+                    if btn:
+                        btn.after(0, lambda: _cfproxy_show_test_results(user_domain, res))
+                except Exception as exc:
+                    log.error("CF proxy test failed: %s", exc)
+                finally:
+                    if btn:
+                        btn.after(0, lambda: btn.configure(text="Тест", state="normal"))
             _threading.Thread(target=_worker, daemon=True).start()
         else:
             def _worker_auto():
-                ok_domain, res = _run_cfproxy_auto_test(balancer.domains)
-                if btn:
-                    btn.after(0, lambda: btn.configure(text="Тест", state="normal"))
-                    btn.after(0, lambda: _cfproxy_show_auto_test_results(ok_domain, res))
+                try:
+                    ok_domain, res = _run_cfproxy_auto_test(balancer.domains)
+                    if btn:
+                        btn.after(0, lambda: _cfproxy_show_auto_test_results(ok_domain, res))
+                except Exception as exc:
+                    log.error("CF proxy auto-test failed: %s", exc)
+                finally:
+                    if btn:
+                        btn.after(0, lambda: btn.configure(text="Тест", state="normal"))
             _threading.Thread(target=_worker_auto, daemon=True).start()
 
     _cf_test_widget = ctk.CTkButton(

--- a/utils/update_check.py
+++ b/utils/update_check.py
@@ -73,7 +73,7 @@ def _parse_version_tuple(s: str) -> tuple:
         return (0,)
     parts = []
     for seg in s.split("."):
-        digits = "".join(c for c in seg if c.isdigit())
+        digits = next((seg[:i] for i, c in enumerate(seg) if not c.isdigit()), seg)
         if digits:
             try:
                 parts.append(int(digits))

--- a/windows.py
+++ b/windows.py
@@ -436,7 +436,11 @@ def _on_edit_config(icon=None, item=None) -> None:
 def _on_open_logs(icon=None, item=None) -> None:
     log.info("Opening log file: %s", LOG_FILE)
     if LOG_FILE.exists():
-        os.startfile(str(LOG_FILE))
+        try:
+            os.startfile(str(LOG_FILE))
+        except Exception as exc:
+            log.error("Failed to open log file: %s", exc)
+            _show_error(f"Не удалось открыть файл логов:\n{exc}")
     else:
         _show_info("Файл логов ещё не создан.")
 
@@ -485,9 +489,15 @@ def _edit_config_dialog() -> None:
             autostart_value=cfg.get("autostart", False),
         )
 
+        _original_appearance = ctk.get_appearance_mode()
+
         def _finish() -> None:
             root.destroy()
             done.set()
+
+        def _cancel() -> None:
+            ctk.set_appearance_mode(_original_appearance)
+            _finish()
 
         def on_save() -> None:
             from tkinter import messagebox
@@ -495,6 +505,13 @@ def _edit_config_dialog() -> None:
             if isinstance(merged, str):
                 messagebox.showerror("TG WS Proxy — Ошибка", merged, parent=root)
                 return
+
+            config_changed = any(merged.get(k) != cfg.get(k) for k in merged)
+
+            if not config_changed:
+                _finish()
+                return
+
             save_config(merged)
             _config.update(merged)
             log.info("Config saved: %s", merged)
@@ -511,8 +528,8 @@ def _edit_config_dialog() -> None:
             if do_restart:
                 threading.Thread(target=lambda: restart_proxy(_config, _show_error), daemon=True).start()
 
-        root.protocol("WM_DELETE_WINDOW", _finish)
-        install_tray_config_buttons(ctk, footer, theme, on_save=on_save, on_cancel=_finish)
+        root.protocol("WM_DELETE_WINDOW", _cancel)
+        install_tray_config_buttons(ctk, footer, theme, on_save=on_save, on_cancel=_cancel)
 
     ctk_run_dialog(_build)
 
@@ -578,7 +595,7 @@ def run_tray() -> None:
 
     _config = load_config()
 
-    if is_windows_dark_theme:
+    if is_windows_dark_theme():
         apply_windows_dark_theme()
 
     bootstrap(_config)

--- a/windows.py
+++ b/windows.py
@@ -506,7 +506,9 @@ def _edit_config_dialog() -> None:
                 messagebox.showerror("TG WS Proxy — Ошибка", merged, parent=root)
                 return
 
+            _ui_only_keys = {"appearance", "autostart", "check_updates"}
             config_changed = any(merged.get(k) != cfg.get(k) for k in merged)
+            proxy_changed = any(merged.get(k) != cfg.get(k) for k in merged if k not in _ui_only_keys)
 
             if not config_changed:
                 _finish()
@@ -518,6 +520,10 @@ def _edit_config_dialog() -> None:
             if _supports_autostart():
                 set_autostart_enabled(bool(merged.get("autostart", False)))
             _tray_icon.menu = _build_menu()
+
+            if not proxy_changed:
+                _finish()
+                return
 
             do_restart = messagebox.askyesno(
                 "Перезапустить?",


### PR DESCRIPTION
- если нажать "Сохранить" ничего не меняя - окно теперь просто закрывается без вопроса про перезапуск
- кнопка "Тест" CF-прокси зависала если тест падал с ошибкой, теперь всегда возвращается в норму
- is_windows_dark_theme вызывался без () - из-за этого тёмная тема применялась у всех независимо от настроек системы
- версии типа 1.6.5-rc1 парсились неправильно, 5-rc1 превращалось в 51
- при отмене диалога настроек тема оформления теперь откатывается обратно