### PR TITLE
docs(README): update preview image source with better visual

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,10 @@
 
 **Локальный MTProto-прокси** для Telegram Desktop, который **ускоряет работу Telegram**, перенаправляя трафик через WebSocket-соединения. Данные передаются в том же зашифрованном виде, а для работы не нужны сторонние серверы.
 
-<img width="529" height="487" alt="image" src="https://github.com/user-attachments/assets/6a4cf683-0df8-43af-86c1-0e8f08682b62" />
+<picture>
+  <source srcset="https://github.com/user-attachments/assets/17f1d15e-e1c2-41ea-a452-220d13359262" media="(prefers-color-scheme: dark)">
+  <img src="https://github.com/user-attachments/assets/4b44f839-f780-40f0-9e29-db5b12bec56b">
+</picture>
 
 ## Как это работает
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@
 
 <picture>
   <source srcset="https://github.com/user-attachments/assets/17f1d15e-e1c2-41ea-a452-220d13359262" media="(prefers-color-scheme: dark)">
-  <img src="https://github.com/user-attachments/assets/4b44f839-f780-40f0-9e29-db5b12bec56b">
+  <img src="https://github.com/user-attachments/assets/8d595468-83a1-4e4f-bac4-9ce4a07027bd">
 </picture>
 
 ## Как это работает


### PR DESCRIPTION
Обновил превью с последней версией программы. Интерфейс автоматически адаптируется под выбранную пользователем тему: в светлом режиме показана светлая версия, в тёмном - тёмная.

# Превью на светлой теме:

<img width="818" height="692" alt="image" src="https://github.com/user-attachments/assets/8afcb4f2-d53b-4a13-b573-bf0855e52b42" />

# Превью на темной теме:

<img width="938" height="786" alt="image" src="https://github.com/user-attachments/assets/f2a32d61-d137-4ab9-bea0-ba2a0cc4fd05" />

# Проверить самому (здесь отображена ваша версия превью):

<picture>
  <source srcset="https://github.com/user-attachments/assets/17f1d15e-e1c2-41ea-a452-220d13359262" media="(prefers-color-scheme: dark)">
  <img src="https://github.com/user-attachments/assets/8d595468-83a1-4e4f-bac4-9ce4a07027bd">
</picture>