### PR TITLE
headless-режим установки на VPS

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and change the values before running on a VPS.
+
+# Public bind address inside the container. Keep 0.0.0.0 for Docker publishing.
+TG_WS_PROXY_HOST=0.0.0.0
+TG_WS_PROXY_PORT=1443
+
+# 32 hex chars. Generate with: openssl rand -hex 16
+TG_WS_PROXY_SECRET=change_me_to_32_hex_chars
+
+# The default pair is intentionally narrow because it is known to work well for
+# many accounts. Add other DC mappings only when you know you need them.
+TG_WS_PROXY_DC_IPS=2:149.154.167.220 4:149.154.167.220
+

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  tg-ws-proxy:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: tg-ws-proxy:local
+    container_name: tg-ws-proxy
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "${TG_WS_PROXY_PORT:-1443}:${TG_WS_PROXY_PORT:-1443}/tcp"
+

--- a/deploy/install-systemd.sh
+++ b/deploy/install-systemd.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+set -eu
+
+APP_DIR="${APP_DIR:-/opt/tg-ws-proxy-core}"
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/tg-ws-vps}"
+APP_USER="${APP_USER:-tgwsproxy}"
+ENV_FILE="${ENV_FILE:-/etc/tg-ws-proxy.env}"
+SERVICE_FILE="/etc/systemd/system/tg-ws-proxy.service"
+CORE_REPO="${CORE_REPO:-https://github.com/Flowseal/tg-ws-proxy.git}"
+CORE_BRANCH="${CORE_BRANCH:-main}"
+PUBLIC_HOST="${TG_WS_PROXY_PUBLIC_HOST:-${PUBLIC_HOST:-}}"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Run as root: sudo sh deploy/install-systemd.sh" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required. Install it first, for example: apt install python3 python3-venv" >&2
+  exit 1
+fi
+
+if ! python3 -m venv --help >/dev/null 2>&1; then
+  echo "python3-venv is required. Install it first, for example: apt install python3-venv" >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required. Install it first, for example: apt install git" >&2
+  exit 1
+fi
+
+if ! id "$APP_USER" >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir "$APP_DIR" --shell /usr/sbin/nologin "$APP_USER"
+fi
+
+run_as_app_user() {
+  if command -v runuser >/dev/null 2>&1; then
+    runuser -u "$APP_USER" -- "$@"
+  else
+    su -s /bin/sh "$APP_USER" -c "$(printf '%s ' "$@")"
+  fi
+}
+
+SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+mkdir -p "$DEPLOY_DIR"
+if [ "$SRC_DIR" != "$DEPLOY_DIR" ]; then
+  cp -R "$SRC_DIR"/. "$DEPLOY_DIR"/
+fi
+
+git config --global --add safe.directory "$APP_DIR" >/dev/null 2>&1 || true
+git config --global --add safe.directory "$DEPLOY_DIR" >/dev/null 2>&1 || true
+
+if [ -d "$APP_DIR/.git" ]; then
+  git -C "$APP_DIR" fetch --prune origin
+  git -C "$APP_DIR" checkout "$CORE_BRANCH"
+  git -C "$APP_DIR" pull --ff-only origin "$CORE_BRANCH"
+else
+  rm -rf "$APP_DIR"
+  git clone --branch "$CORE_BRANCH" "$CORE_REPO" "$APP_DIR"
+fi
+
+chown -R "$APP_USER:$APP_USER" "$APP_DIR"
+chown -R root:root "$DEPLOY_DIR"
+
+if [ ! -d "$APP_DIR/.venv" ]; then
+  run_as_app_user python3 -m venv "$APP_DIR/.venv"
+fi
+
+run_as_app_user "$APP_DIR/.venv/bin/pip" install --upgrade pip
+run_as_app_user "$APP_DIR/.venv/bin/pip" install cryptography==46.0.5
+
+if [ ! -f "$ENV_FILE" ]; then
+  cp "$DEPLOY_DIR/deploy/systemd/tg-ws-proxy.env.example" "$ENV_FILE"
+  if command -v openssl >/dev/null 2>&1; then
+    SECRET="$(openssl rand -hex 16)"
+  else
+    SECRET="$(python3 -c 'import os; print(os.urandom(16).hex())')"
+  fi
+  sed -i "s/change_me_to_32_hex_chars/$SECRET/" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+fi
+
+SECRET="$(sed -n 's/^TG_WS_PROXY_SECRET=//p' "$ENV_FILE" | tail -n 1)"
+if ! printf '%s' "$SECRET" | grep -Eq '^[0-9a-fA-F]{32}$'; then
+  if command -v openssl >/dev/null 2>&1; then
+    SECRET="$(openssl rand -hex 16)"
+  else
+    SECRET="$(python3 -c 'import os; print(os.urandom(16).hex())')"
+  fi
+  if grep -q '^TG_WS_PROXY_SECRET=' "$ENV_FILE"; then
+    sed -i "s/^TG_WS_PROXY_SECRET=.*/TG_WS_PROXY_SECRET=$SECRET/" "$ENV_FILE"
+  else
+    printf '\nTG_WS_PROXY_SECRET=%s\n' "$SECRET" >> "$ENV_FILE"
+  fi
+fi
+
+PORT="$(sed -n 's/^TG_WS_PROXY_PORT=//p' "$ENV_FILE" | tail -n 1)"
+PORT="${PORT:-1443}"
+
+chmod +x "$DEPLOY_DIR/deploy/systemd/run-headless.sh"
+chmod +x "$DEPLOY_DIR/deploy/systemd/update-headless.sh"
+cp "$DEPLOY_DIR/deploy/systemd/tg-ws-proxy.service" "$SERVICE_FILE"
+cp "$DEPLOY_DIR/deploy/systemd/tg-ws-proxy-update.service" /etc/systemd/system/tg-ws-proxy-update.service
+cp "$DEPLOY_DIR/deploy/systemd/tg-ws-proxy-update.timer" /etc/systemd/system/tg-ws-proxy-update.timer
+
+systemctl daemon-reload
+systemctl enable --now tg-ws-proxy
+systemctl enable --now tg-ws-proxy-update.timer
+
+if [ -z "$PUBLIC_HOST" ]; then
+  if command -v curl >/dev/null 2>&1; then
+    PUBLIC_HOST="$(curl -fsS --max-time 5 https://api.ipify.org 2>/dev/null || true)"
+  fi
+fi
+
+if [ -z "$PUBLIC_HOST" ]; then
+  PUBLIC_HOST="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+fi
+
+echo "tg-ws-proxy installed and started."
+echo "Core directory: $APP_DIR"
+echo "Deploy directory: $DEPLOY_DIR"
+echo "Show logs with: journalctl -u tg-ws-proxy -n 80 --no-pager"
+echo "Auto-update timer: systemctl list-timers tg-ws-proxy-update.timer"
+if [ -n "$PUBLIC_HOST" ]; then
+  echo
+  echo "Telegram proxy link:"
+  echo "tg://proxy?server=$PUBLIC_HOST&port=$PORT&secret=dd$SECRET"
+else
+  echo
+  echo "Could not detect public host automatically."
+  echo "Run again with: sudo TG_WS_PROXY_PUBLIC_HOST=YOUR_VPS_IP sh deploy/install-systemd.sh"
+fi

--- a/deploy/systemd/run-headless.sh
+++ b/deploy/systemd/run-headless.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+HOST="${TG_WS_PROXY_HOST:-0.0.0.0}"
+PORT="${TG_WS_PROXY_PORT:-1443}"
+SECRET="${TG_WS_PROXY_SECRET:?TG_WS_PROXY_SECRET must be set}"
+DC_IPS="${TG_WS_PROXY_DC_IPS:-2:149.154.167.220 4:149.154.167.220}"
+APP_DIR="${APP_DIR:-/opt/tg-ws-proxy-core}"
+
+set -- --host "$HOST" --port "$PORT" --secret "$SECRET"
+
+for dc in $DC_IPS; do
+  set -- "$@" --dc-ip "$dc"
+done
+
+cd "$APP_DIR"
+exec "$APP_DIR/.venv/bin/python" -u proxy/tg_ws_proxy.py "$@"

--- a/deploy/systemd/tg-ws-proxy-update.service
+++ b/deploy/systemd/tg-ws-proxy-update.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Update TG WS Proxy from git
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /opt/tg-ws-vps/deploy/systemd/update-headless.sh

--- a/deploy/systemd/tg-ws-proxy-update.timer
+++ b/deploy/systemd/tg-ws-proxy-update.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily TG WS Proxy auto-update
+
+[Timer]
+OnCalendar=*-*-* 04:17:00
+RandomizedDelaySec=45m
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+

--- a/deploy/systemd/tg-ws-proxy.env.example
+++ b/deploy/systemd/tg-ws-proxy.env.example
@@ -1,0 +1,6 @@
+# Copy to /etc/tg-ws-proxy.env and change values.
+TG_WS_PROXY_HOST=0.0.0.0
+TG_WS_PROXY_PORT=1443
+TG_WS_PROXY_SECRET=change_me_to_32_hex_chars
+TG_WS_PROXY_DC_IPS=2:149.154.167.220 4:149.154.167.220
+

--- a/deploy/systemd/tg-ws-proxy.service
+++ b/deploy/systemd/tg-ws-proxy.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=TG WS Proxy headless service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tgwsproxy
+Group=tgwsproxy
+WorkingDirectory=/opt/tg-ws-proxy-core
+EnvironmentFile=/etc/tg-ws-proxy.env
+ExecStart=/bin/sh /opt/tg-ws-vps/deploy/systemd/run-headless.sh
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/update-headless.sh
+++ b/deploy/systemd/update-headless.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+APP_DIR="${APP_DIR:-/opt/tg-ws-proxy-core}"
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/tg-ws-vps}"
+SERVICE_NAME="${SERVICE_NAME:-tg-ws-proxy.service}"
+PIP="${APP_DIR}/.venv/bin/pip"
+
+git config --global --add safe.directory "$APP_DIR" >/dev/null 2>&1 || true
+git config --global --add safe.directory "$DEPLOY_DIR" >/dev/null 2>&1 || true
+
+if [ -d "$DEPLOY_DIR/.git" ]; then
+  git -C "$DEPLOY_DIR" fetch --prune
+  git -C "$DEPLOY_DIR" pull --ff-only
+fi
+
+cd "$APP_DIR"
+
+if [ ! -d .git ]; then
+  echo "Skip update: $APP_DIR is not a git checkout"
+  exit 0
+fi
+
+OLD_HEAD="$(git rev-parse HEAD)"
+
+git fetch --prune
+git pull --ff-only origin main
+
+NEW_HEAD="$(git rev-parse HEAD)"
+
+if [ "$OLD_HEAD" = "$NEW_HEAD" ]; then
+  echo "tg-ws-proxy is already up to date at $NEW_HEAD"
+  exit 0
+fi
+
+if [ -x "$PIP" ]; then
+  "$PIP" install cryptography==46.0.5
+fi
+
+systemctl restart "$SERVICE_NAME"
+
+echo "tg-ws-proxy updated: $OLD_HEAD -> $NEW_HEAD"

--- a/docs/VPS.md
+++ b/docs/VPS.md
@@ -1,0 +1,182 @@
+# TG WS Proxy на VPS без GUI
+
+Да, этот проект можно запускать на обычном Linux VPS без графического окружения. GUI-файлы `windows.py`, `macos.py`, `linux.py`, `ui/` и tray-логика нужны только для локального приложения в трее. Сам прокси запускается отдельно через `proxy/tg_ws_proxy.py` или консольную команду `tg-ws-proxy`.
+
+## Что будет работать
+
+На сервере прокси слушает TCP-порт, например `0.0.0.0:1443`, принимает MTProto-подключения от Telegram-клиента и дальше ходит к Telegram DC через WebSocket/TLS или fallback-механизмы проекта.
+
+Схема:
+
+```text
+Telegram client -> VPS:1443 -> tg-ws-proxy -> Telegram WebSocket/DC
+```
+
+На VPS не нужны X11, Wayland, desktop environment, tray, tkinter, pystray или AppIndicator, если запускать headless-вход.
+
+## Важные условия
+
+- VPS должен иметь исходящий доступ к `*.web.telegram.org:443` и/или fallback-направлениям.
+- Входящий TCP-порт, например `1443`, должен быть открыт в firewall VPS и панели провайдера.
+- В Telegram нужно указывать публичный IP или домен VPS, а не `127.0.0.1`.
+- `secret` должен быть фиксированным. Если не задать его явно, при каждом новом запуске будет генерироваться новый ключ, и старая ссылка перестанет работать.
+- Если VPS находится в сети, где сам Telegram/WebSocket недоступен или активно режется, может понадобиться Cloudflare fallback, Worker или Fake TLS/Nginx из существующих инструкций проекта.
+
+## Вариант 1: Docker Compose
+
+На сервере:
+
+```bash
+git clone https://github.com/Flowseal/tg-ws-proxy.git
+cd tg-ws-proxy/deploy
+cp .env.example .env
+openssl rand -hex 16
+```
+
+Вставьте результат `openssl rand -hex 16` в `TG_WS_PROXY_SECRET` внутри `.env`.
+
+Запуск:
+
+```bash
+docker compose up -d --build
+docker logs tg-ws-proxy
+```
+
+В логах будет строка вида:
+
+```text
+tg://proxy?server=0.0.0.0&port=1443&secret=dd...
+```
+
+Для подключения замените `server=0.0.0.0` на публичный IP или домен VPS:
+
+```text
+tg://proxy?server=YOUR_VPS_IP&port=1443&secret=ddYOUR_SECRET
+```
+
+Проверка:
+
+```bash
+docker ps
+docker logs --tail=80 tg-ws-proxy
+ss -lntp | grep 1443
+```
+
+## Вариант 2: systemd без Docker
+
+### Быстрая установка
+
+Если приватный deploy-репозиторий уже находится на VPS, можно запустить установщик:
+
+```bash
+sudo sh deploy/install-systemd.sh
+```
+
+Чтобы сразу получить корректную ссылку с публичным IP, передайте адрес VPS:
+
+```bash
+sudo TG_WS_PROXY_PUBLIC_HOST=YOUR_VPS_IP_OR_DOMAIN sh deploy/install-systemd.sh
+```
+
+Скрипт:
+
+- создаст системного пользователя `tgwsproxy`;
+- скопирует приватную deploy-обертку в `/opt/tg-ws-vps`, если запущен не оттуда;
+- скачает чистый core из `https://github.com/Flowseal/tg-ws-proxy.git` в `/opt/tg-ws-proxy-core`;
+- создаст `.venv` в `/opt/tg-ws-proxy-core`;
+- установит минимальную зависимость `cryptography`;
+- создаст `/etc/tg-ws-proxy.env` с постоянным secret;
+- включит и запустит `tg-ws-proxy.service`;
+- включит ежедневный автоапдейт через `tg-ws-proxy-update.timer`;
+- выведет готовую ссылку `tg://proxy?...`.
+
+После запуска посмотрите логи:
+
+```bash
+journalctl -u tg-ws-proxy -n 80 --no-pager
+```
+
+Проверить автоапдейт:
+
+```bash
+systemctl list-timers tg-ws-proxy-update.timer
+systemctl status tg-ws-proxy-update.timer
+```
+
+Запустить обновление вручную:
+
+```bash
+sudo systemctl start tg-ws-proxy-update.service
+journalctl -u tg-ws-proxy-update -n 80 --no-pager
+```
+
+## Как устроены автообновления
+
+На VPS используются две директории:
+
+```text
+/opt/tg-ws-proxy-core  -> чистый публичный core Flowseal/tg-ws-proxy
+/opt/tg-ws-vps         -> приватная deploy/config-обертка Amadest/tg-ws-vps
+```
+
+Сервис запускает код из `/opt/tg-ws-proxy-core`, но берет systemd-скрипты и настройки из приватной обертки. Ежедневный timer делает:
+
+```text
+git pull --ff-only в /opt/tg-ws-vps
+git pull --ff-only origin main в /opt/tg-ws-proxy-core
+restart tg-ws-proxy, если core изменился
+```
+
+Так обновления основной публичной репы не конфликтуют с приватными настройками VPS.
+
+### Ручная установка
+
+Пример для Debian/Ubuntu:
+
+```bash
+sudo apt update
+sudo apt install -y git python3 python3-venv python3-pip
+sudo useradd --system --create-home --home-dir /opt/tg-ws-proxy --shell /usr/sbin/nologin tgwsproxy
+sudo git clone https://github.com/Flowseal/tg-ws-proxy.git /opt/tg-ws-proxy
+sudo chown -R tgwsproxy:tgwsproxy /opt/tg-ws-proxy
+sudo -u tgwsproxy python3 -m venv /opt/tg-ws-proxy/.venv
+sudo -u tgwsproxy /opt/tg-ws-proxy/.venv/bin/pip install --upgrade pip
+sudo -u tgwsproxy /opt/tg-ws-proxy/.venv/bin/pip install cryptography==46.0.5
+```
+
+Настройка:
+
+```bash
+sudo cp /opt/tg-ws-proxy/deploy/systemd/tg-ws-proxy.env.example /etc/tg-ws-proxy.env
+openssl rand -hex 16
+sudo nano /etc/tg-ws-proxy.env
+sudo cp /opt/tg-ws-proxy/deploy/systemd/tg-ws-proxy.service /etc/systemd/system/tg-ws-proxy.service
+sudo chmod +x /opt/tg-ws-proxy/deploy/systemd/run-headless.sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now tg-ws-proxy
+```
+
+Проверка:
+
+```bash
+systemctl status tg-ws-proxy
+journalctl -u tg-ws-proxy -n 80 --no-pager
+ss -lntp | grep 1443
+```
+
+## Firewall
+
+Если используется `ufw`:
+
+```bash
+sudo ufw allow 1443/tcp
+sudo ufw status
+```
+
+Если порт закрыт в панели провайдера, его нужно открыть там тоже.
+
+## Когда нужен домен и Nginx
+
+Для простого режима достаточно публичного IP VPS и открытого TCP-порта.
+
+Домен, Nginx и Fake TLS нужны, когда хочется маскировать прокси под обычный TLS-сайт, прокидывать трафик через 443 или прятать сервис за более правдоподобным SNI. В проекте уже есть опции `--fake-tls-domain` и `--proxy-protocol`, а отдельная инструкция лежит в `docs/FakeTlsNginx.md`.


### PR DESCRIPTION
## Что сделано

Добавлен headless-сценарий установки `tg-ws-proxy` на обычный Linux VPS без GUI, tray, X11/Wayland, tkinter, pystray и AppIndicator.

В проекте уже есть консольная точка входа `proxy/tg_ws_proxy.py`, поэтому для серверного запуска достаточно оформить вокруг нее удобный systemd/Docker-деплой.

В PR добавлены:

- `deploy/install-systemd.sh` — установщик для VPS;
- `deploy/systemd/tg-ws-proxy.service` — systemd-сервис для запуска прокси;
- `deploy/systemd/tg-ws-proxy-update.timer` и `deploy/systemd/tg-ws-proxy-update.service` — ежедневный автоапдейт;
- `deploy/systemd/run-headless.sh` — headless-wrapper для запуска CLI-прокси;
- `deploy/systemd/update-headless.sh` — обновление через `git pull --ff-only`;
- `deploy/.env.example` и `deploy/systemd/tg-ws-proxy.env.example` — примеры конфигурации;
- `deploy/docker-compose.yml` — простой Docker Compose вариант;
- `docs/VPS.md` — инструкция по установке на VPS.

## Зачем

Сейчас основной пользовательский сценарий хорошо покрывает desktop/tray-использование. Но если хочется один раз поставить прокси на VPS и забыть, GUI-обертка не нужна и даже мешает: на сервере обычно нет графического окружения и системного трея.

Этот PR добавляет отдельный серверный путь:

`Telegram client -> VPS:1443 -> tg-ws-proxy -> Telegram WebSocket/DC`

## Как работает systemd-установка

Установщик:

- создает системного пользователя `tgwsproxy`;
- клонирует чистый публичный core проекта в `/opt/tg-ws-proxy-core`;
- создает virtualenv;
- ставит минимальную зависимость `cryptography`;
- создает `/etc/tg-ws-proxy.env` со стабильным `TG_WS_PROXY_SECRET`;
- включает и запускает `tg-ws-proxy.service`;
- печатает готовую ссылку `tg://proxy?...`.

Пример запуска:

`sudo TG_WS_PROXY_PUBLIC_HOST=YOUR_VPS_IP_OR_DOMAIN sh deploy/install-systemd.sh`

После установки сервис можно проверить так:

`systemctl status tg-ws-proxy`

Логи:

`journalctl -u tg-ws-proxy -n 80 --no-pager`

## Автообновления

Добавлен systemd timer, который раз в сутки делает обновление через git.

Он обновляет публичный core:

`/opt/tg-ws-proxy-core -> git pull --ff-only origin main`

Если core изменился, сервис перезапускается. Если изменений нет, сервис не трогается.

Secret хранится отдельно в `/etc/tg-ws-proxy.env`, поэтому ссылка подключения не ломается после рестартов и обновлений.

Проверка таймера:

`systemctl list-timers tg-ws-proxy-update.timer`

Ручной запуск обновления:

`sudo systemctl start tg-ws-proxy-update.service`

Логи обновления:

`journalctl -u tg-ws-proxy-update -n 80 --no-pager`

## Docker Compose

Также добавлен минимальный Docker Compose сценарий для тех, кто предпочитает контейнерный запуск.

Пример:

1. Перейти в директорию `deploy`.
2. Скопировать `.env.example` в `.env`.
3. Указать `TG_WS_PROXY_SECRET`.
4. Запустить `docker compose up -d --build`.

Контейнер публикует порт `1443/tcp`, использует переменные окружения из `.env` и перезапускается через `restart: unless-stopped`.

## Совместимость

Изменения не затрагивают tray-приложения для Windows, macOS и Linux. Новый сценарий добавляет отдельный способ запуска для серверов и использует уже существующий proxy core.