### PR TITLE
fix: поддержка IPv6-адресов в --dc-ip

### DIFF
--- a/proxy/config.py
+++ b/proxy/config.py
@@ -186,6 +186,15 @@ def start_cfproxy_domain_refresh() -> None:
     threading.Thread(target=_loop, daemon=True, name='cfproxy-domains-refresh').start()
 
 
+def _validate_ip(ip_s: str) -> None:
+    try:
+        _socket.inet_pton(_socket.AF_INET, ip_s)
+        return
+    except OSError:
+        pass
+    _socket.inet_pton(_socket.AF_INET6, ip_s)
+
+
 def parse_dc_ip_list(dc_ip_list: List[str]) -> Dict[int, str]:
     dc_redirects: Dict[int, str] = {}
     for entry in dc_ip_list:
@@ -195,7 +204,7 @@ def parse_dc_ip_list(dc_ip_list: List[str]) -> Dict[int, str]:
         dc_s, ip_s = entry.split(':', 1)
         try:
             dc_n = int(dc_s)
-            _socket.inet_aton(ip_s)
+            _validate_ip(ip_s)
         except (ValueError, OSError):
             raise ValueError(f"Invalid --dc-ip {entry!r}")
         dc_redirects[dc_n] = ip_s


### PR DESCRIPTION
﻿## Что сделано
- `parse_dc_ip_list` теперь проверяет IP через `socket.inet_pton` (сначала `AF_INET`, затем `AF_INET6`) вместо `inet_aton`.

## Зачем
`inet_aton` понимает только IPv4, поэтому записи `--dc-ip` с IPv6-адресами отклонялись с ошибкой `Invalid --dc-ip`, хотя остальной конвейер (`asyncio.open_connection`) с IPv6 работает нормально. Из-за этого нельзя было задать IPv6-адрес датацентра вручную.

`inet_pton` валидирует обе версии адресов, поэтому теперь `--dc-ip 2:2001:67c:4e8::a` принимается корректно, а явно битые значения по-прежнему отклоняются.

## Как проверить
- `python -m proxy.tg_ws_proxy --dc-ip 2:2001:67c:4e8::a` — запускается без ошибки конфигурации.
- `python -m ruff check proxy/config.py` — без замечаний.
- Локально проверено юнит-тестами: IPv4 → принят, IPv6 → принят, смешанный список → принят, мусор / отсутствие двоеточия / нечисловой DC → отклонены.



---
> Примечание: этот PR и PR с media-aware выбором IP оба правят parse_dc_ip_list. Какой будет смержен вторым — потребует тривиального ребейза одной строки (валидация IP). Готов поправить.
