### PR TITLE
fix: выбор IP датацентра с учётом медиа-трафика

### DIFF
--- a/proxy/config.py
+++ b/proxy/config.py
@@ -6,7 +6,7 @@ import socket as _socket
 import threading
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 from urllib.request import Request
 
 from .balancer import balancer
@@ -55,6 +55,7 @@ class ProxyConfig:
     host: str = '127.0.0.1'
     secret: str = field(default_factory=lambda: os.urandom(16).hex())
     dc_redirects: Dict[int, str] = field(default_factory=lambda: {2: '149.154.167.220', 4: '149.154.167.220'})
+    media_redirects: Dict[int, str] = field(default_factory=dict)
     buffer_size: int = 256 * 1024
     pool_size: int = 4
     fallback_cfproxy: bool = True
@@ -186,17 +187,35 @@ def start_cfproxy_domain_refresh() -> None:
     threading.Thread(target=_loop, daemon=True, name='cfproxy-domains-refresh').start()
 
 
-def parse_dc_ip_list(dc_ip_list: List[str]) -> Dict[int, str]:
+def parse_dc_ip_list(
+        dc_ip_list: List[str]) -> Tuple[Dict[int, str], Dict[int, str]]:
     dc_redirects: Dict[int, str] = {}
+    media_redirects: Dict[int, str] = {}
     for entry in dc_ip_list:
         if ':' not in entry:
             raise ValueError(
                 f"Invalid --dc-ip format {entry!r}, expected DC:IP")
         dc_s, ip_s = entry.split(':', 1)
+        is_media = dc_s.endswith('m')
+        if is_media:
+            dc_s = dc_s[:-1]
         try:
             dc_n = int(dc_s)
             _socket.inet_aton(ip_s)
         except (ValueError, OSError):
             raise ValueError(f"Invalid --dc-ip {entry!r}")
-        dc_redirects[dc_n] = ip_s
-    return dc_redirects
+        if is_media:
+            media_redirects[dc_n] = ip_s
+        else:
+            dc_redirects[dc_n] = ip_s
+    return dc_redirects, media_redirects
+
+
+def resolve_dc_ip(dc_redirects: Dict[int, str],
+                  media_redirects: Dict[int, str],
+                  dc: int, is_media: bool) -> Optional[str]:
+    if is_media:
+        ip = media_redirects.get(dc)
+        if ip is not None:
+            return ip
+    return dc_redirects.get(dc)

--- a/proxy/pool.py
+++ b/proxy/pool.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple, Set
 
 from .raw_websocket import RawWebSocket, WsHandshakeError
 from .stats import stats
-from .config import proxy_config
+from .config import proxy_config, resolve_dc_ip
 from .utils import ws_domains, DC_DEFAULT_IPS
 
 log = logging.getLogger('tg-mtproto-proxy')
@@ -97,13 +97,17 @@ class _WsPool:
             pass
 
     async def warmup(self):
-        for dc, target_ip in proxy_config.dc_redirects.items():
-            if target_ip is None:
-                continue
+        dcs = set(proxy_config.dc_redirects) | set(proxy_config.media_redirects)
+        for dc in dcs:
             for is_media in (False, True):
+                target_ip = resolve_dc_ip(proxy_config.dc_redirects,
+                                          proxy_config.media_redirects,
+                                          dc, is_media)
+                if target_ip is None:
+                    continue
                 domains = ws_domains(dc, is_media)
                 self._schedule_refill((dc, is_media), target_ip, domains)
-        log.info("WS pool warmup started for %d DC(s)", len(proxy_config.dc_redirects))
+        log.info("WS pool warmup started for %d DC(s)", len(dcs))
 
     def reset(self):
         self._idle.clear()

--- a/proxy/tg_ws_proxy.py
+++ b/proxy/tg_ws_proxy.py
@@ -22,7 +22,7 @@ if __name__ == '__main__' and (__package__ is None or __package__ == ''):
 
 from .utils import *
 from .stats import stats
-from .config import proxy_config, parse_dc_ip_list, start_cfproxy_domain_refresh, coerce_domain_list
+from .config import proxy_config, parse_dc_ip_list, resolve_dc_ip, start_cfproxy_domain_refresh, coerce_domain_list
 from .bridge import MsgSplitter, CryptoCtx, do_fallback, bridge_ws_reencrypt
 from .raw_websocket import RawWebSocket, WsHandshakeError, set_sock_opts
 from .fake_tls import proxy_to_masking_domain, verify_client_hello, build_server_hello, FakeTlsStream, TLS_RECORD_HANDSHAKE
@@ -290,9 +290,13 @@ async def _handle_client(reader, writer, secret: bytes):
         dc_key = f'{dc}{"m" if is_media else ""}'
         media_tag = " media" if is_media else ""
 
+        # Resolve target IP (media-aware) and fall back when unavailable.
+        target = resolve_dc_ip(proxy_config.dc_redirects,
+                               proxy_config.media_redirects, dc, is_media)
+
         # Fallback if DC not in config or WS blacklisted for this DC/is_media
-        if dc not in proxy_config.dc_redirects or dc_key in ws_blacklist:
-            if dc not in proxy_config.dc_redirects:
+        if target is None or dc_key in ws_blacklist:
+            if target is None:
                 log.info("[%s] DC%d not in config -> fallback",
                          label, dc)
             else:
@@ -317,7 +321,6 @@ async def _handle_client(reader, writer, secret: bytes):
         ws_timeout = WS_FAIL_TIMEOUT if now < fail_until else 10.0
 
         domains = ws_domains(dc, is_media)
-        target = proxy_config.dc_redirects[dc]
         ws = None
         ws_failed_redirect = False
         all_redirects = True
@@ -483,6 +486,9 @@ async def _run(stop_event: Optional[asyncio.Event] = None):
     for dc in sorted(proxy_config.dc_redirects.keys()):
         ip = proxy_config.dc_redirects.get(dc)
         log.info("    DC%d: %s", dc, ip)
+    for dc in sorted(proxy_config.media_redirects.keys()):
+        ip = proxy_config.media_redirects.get(dc)
+        log.info("    DC%d media: %s", dc, ip)
     if proxy_config.fallback_cfproxy:
         user_domain = "user" if proxy_config.cfproxy_user_domains else "auto"
         log.info("  CF proxy:      enabled (%s)", user_domain)
@@ -561,7 +567,10 @@ def main():
                     help='MTProto proxy secret (32 hex chars). '
                          'Auto-generated if not provided.')
     ap.add_argument('--dc-ip', metavar='DC:IP', action='append',
-                    help='Target IP for a DC, e.g. --dc-ip 2:149.154.167.220')
+                    help='Target IP for a DC, e.g. --dc-ip 2:149.154.167.220. '
+                         'Suffix the DC with "m" for a media-only override, '
+                         'e.g. --dc-ip 2m:149.154.167.220 (falls back to the '
+                         'plain DC IP when omitted).')
     ap.add_argument('-v', '--verbose', action='store_true',
                     help='Debug logging')
     ap.add_argument('--log-file', type=str, default=None, metavar='PATH',
@@ -598,7 +607,7 @@ def main():
         args.dc_ip = ['2:149.154.167.220', '4:149.154.167.220']
 
     try:
-        dc_redirects = parse_dc_ip_list(args.dc_ip)
+        dc_redirects, media_redirects = parse_dc_ip_list(args.dc_ip)
     except ValueError as e:
         log.error(str(e))
         sys.exit(1)
@@ -621,6 +630,7 @@ def main():
     proxy_config.host = args.host
     proxy_config.secret = secret_hex
     proxy_config.dc_redirects = dc_redirects
+    proxy_config.media_redirects = media_redirects
     proxy_config.buffer_size = max(4, args.buf_kb) * 1024
     proxy_config.pool_size = max(0, args.pool_size)
     proxy_config.fallback_cfproxy = not args.no_cfproxy

--- a/utils/tray_common.py
+++ b/utils/tray_common.py
@@ -258,7 +258,7 @@ def _run_proxy_thread(on_port_busy: Callable[[str], None]) -> None:
 def apply_proxy_config(cfg: dict) -> bool:
     dc_ip_list = cfg.get("dc_ip", DEFAULT_CONFIG["dc_ip"])
     try:
-        dc_redirects = parse_dc_ip_list(dc_ip_list)
+        dc_redirects, media_redirects = parse_dc_ip_list(dc_ip_list)
     except ValueError as e:
         log.error("Bad config dc_ip: %s", e)
         return False
@@ -268,6 +268,7 @@ def apply_proxy_config(cfg: dict) -> bool:
     pc.host = cfg.get("host", DEFAULT_CONFIG["host"])
     pc.secret = cfg.get("secret", DEFAULT_CONFIG["secret"])
     pc.dc_redirects = dc_redirects
+    pc.media_redirects = media_redirects
     pc.buffer_size = max(4, cfg.get("buf_kb", DEFAULT_CONFIG["buf_kb"])) * 1024
     pc.pool_size = max(0, cfg.get("pool_size", DEFAULT_CONFIG["pool_size"]))
     pc.fallback_cfproxy = cfg.get("cfproxy", DEFAULT_CONFIG["cfproxy"])


### PR DESCRIPTION
﻿## Что сделано
- Раздельная маршрутизация медиа- и обычного трафика по DC. Синтаксис `--dc-ip` расширен: суффикс `m` у номера DC задаёт IP только для медиа, например `--dc-ip 2m:149.154.167.220`.
- `parse_dc_ip_list` теперь возвращает кортеж `(dc_redirects, media_redirects)`; добавлена функция `resolve_dc_ip(...)`, централизующая выбор адреса с учётом `is_media`.
- `resolve_dc_ip` используется в трёх местах: клиентский путь, прогрев WS-пула (`pool.warmup`) и стартовая диагностика. Добавлено поле `media_redirects` в `ProxyConfig` и проброс в трее (`tray_common.apply_proxy_config`).

## Зачем
Выбор IP раньше шёл только по номеру DC (`dc_redirects[dc]`), флаг `is_media` на адрес не влиял. Медиа- и обычный трафик одного DC принудительно шли на один адрес — именно поэтому в документации CfWorker приходится «сливать» всё через единственную запись `4:149.154.167.220`, чтобы заработала загрузка медиа.

Теперь для медиа можно задать отдельный адрес, а при отсутствии медиа-записи происходит фолбэк на обычный IP этого DC — обратная совместимость полная.

## Как проверить
- `python -m ruff check proxy/config.py proxy/pool.py proxy/tg_ws_proxy.py utils/tray_common.py` — без замечаний.
- Запустить прокси, подключить Telegram Desktop: в логе медиа-сессии идут отдельной веткой (`DC2 media -> wss://kws2-1.web.telegram.org/apiws`), обычные — своей (`DC2 -> wss://kws2...`).
- Пример раздельной маршрутизации: `--dc-ip 2:IP_A --dc-ip 2m:IP_B` → обычный трафик DC2 идёт на IP_A, медиа — на IP_B.
- Локально проверено юнит-тестами: разбор обычных и медиа-записей, медиа-переопределение, фолбэк на обычный IP, неизвестный DC.



---
> Примечание: этот PR и PR с поддержкой IPv6 в --dc-ip оба правят parse_dc_ip_list. Какой будет смержен вторым — потребует тривиального ребейза одной строки (валидация IP). Готов поправить.
