### PR TITLE
fix: WS keepalive-пинги против обрыва простаивающих сессий (#646)

### DIFF
--- a/proxy/bridge.py
+++ b/proxy/bridge.py
@@ -263,6 +263,23 @@ async def _tcp_fallback(reader, writer, dst, port, relay_init, label, ctx: Crypt
     return True
 
 
+async def _ws_keepalive(ws, interval: float):
+    """Send periodic WS PING frames to keep the upstream flow warm.
+
+    A non-positive interval disables keepalive. The loop exits on send
+    failure so a dead upstream is detected promptly instead of lingering
+    until the next client packet (see issue #646).
+    """
+    if interval <= 0:
+        return
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            await ws.send_ping()
+    except (asyncio.CancelledError, ConnectionError, OSError):
+        return
+
+
 async def bridge_ws_reencrypt(reader, writer, ws: RawWebSocket, label,
                                ctx: CryptoCtx,
                                dc=None, is_media=False,
@@ -334,12 +351,15 @@ async def bridge_ws_reencrypt(reader, writer, ws: RawWebSocket, label,
 
     tasks = [asyncio.create_task(tcp_to_ws()),
              asyncio.create_task(ws_to_tcp())]
+    keepalive = asyncio.ensure_future(
+        _ws_keepalive(ws, proxy_config.ws_keepalive_interval))
     try:
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
     finally:
+        keepalive.cancel()
         for t in tasks:
             t.cancel()
-        for t in tasks:
+        for t in (*tasks, keepalive):
             try:
                 await t
             except BaseException:

--- a/proxy/config.py
+++ b/proxy/config.py
@@ -62,6 +62,7 @@ class ProxyConfig:
     cfproxy_worker_domains: List[str] = field(default_factory=list)
     fake_tls_domain: str = ''
     proxy_protocol: bool = False
+    ws_keepalive_interval: float = 30.0
 
 
 proxy_config = ProxyConfig()

--- a/proxy/raw_websocket.py
+++ b/proxy/raw_websocket.py
@@ -154,6 +154,13 @@ class RawWebSocket:
                 self._build_frame(self.OP_BINARY, part, mask=True))
         await self.writer.drain()
 
+    async def send_ping(self, payload: bytes = b''):
+        if self._closed:
+            raise ConnectionError("WebSocket closed")
+        frame = self._build_frame(self.OP_PING, payload, mask=True)
+        self.writer.write(frame)
+        await self.writer.drain()
+
     async def recv(self) -> Optional[bytes]:
         while not self._closed:
             opcode, payload = await self._read_frame()

--- a/proxy/tg_ws_proxy.py
+++ b/proxy/tg_ws_proxy.py
@@ -592,6 +592,10 @@ def main():
     ap.add_argument('--proxy-protocol', action='store_true',
                     help='Accept PROXY protocol v1 header '
                          '(for use behind nginx/haproxy with proxy_protocol on)')
+    ap.add_argument('--ws-keepalive', type=float, default=30.0, metavar='SEC',
+                    help='Seconds between WebSocket keepalive PINGs to the '
+                         'upstream (default 30, 0 to disable). Keeps idle '
+                         'sessions alive through NAT/firewall timeouts.')
     args = ap.parse_args()
 
     if not args.dc_ip:
@@ -628,6 +632,7 @@ def main():
     proxy_config.cfproxy_worker_domains = coerce_domain_list(args.cfproxy_worker_domain)
     proxy_config.fake_tls_domain = args.fake_tls_domain.strip()
     proxy_config.proxy_protocol = args.proxy_protocol
+    proxy_config.ws_keepalive_interval = max(0.0, args.ws_keepalive)
 
     log_level = logging.DEBUG if args.verbose else logging.INFO
     log_fmt = logging.Formatter('%(asctime)s  %(levelname)-5s  %(message)s',


### PR DESCRIPTION
﻿## Что сделано
- Добавлен `RawWebSocket.send_ping()` — отправка WS-фрейма OP_PING (маскированного, как требует протокол для клиента).
- Добавлен цикл `_ws_keepalive()` в `bridge_ws_reencrypt`, который шлёт PING на upstream каждые `--ws-keepalive` секунд (по умолчанию **30**, `0` — отключить).
- Флаг `--ws-keepalive SEC` в CLI и поле `ws_keepalive_interval` в `ProxyConfig` (дефолт 30с — фикс активен и для GUI/трея).

## Зачем (разбор #646)
Долгие сессии рвались через случайный интервал простоя: Telegram показывал «прокси использует некорректные настройки», хотя сам прокси оставался жив, а мгновенное переподключение всё чинило.

Причина — тихий обрыв простаивающего соединения. Прокси **отвечал** на входящие PING, но **сам не слал** keepalive, и `SO_KEEPALIVE` не выставлялся. Stateful-устройство на пути (NAT-таблица домашнего роутера / мобильный CGNAT, либо idle-таймаут CF edge) выкидывает простаивающий поток; следующий пакет упирается в мёртвое соединение → RST. Тот же симптом в независимой **go-реализации** указывает на причину в транспорте/NAT, а не в Python-коде.

Периодический PING держит NAT-маппинги «тёплыми». Дополнительно: при сбое отправки пинга сессия теперь закрывается сразу, а не висит до следующего пакета клиента.

## Поведение по умолчанию
Keepalive **включён** (30с). Отключить: `--ws-keepalive 0`.

## Как проверить
- `py_compile` для `proxy/bridge.py`, `proxy/raw_websocket.py`, `proxy/config.py`, `proxy/tg_ws_proxy.py` — без ошибок.
- **Полевая проверка пройдена:** Telegram Desktop через прокси, простой 15 минут — сессия осталась живой, сообщения уходят мгновенно без переподключения (раньше на той же сети рвалось).
- Локально проверено юнит-тестами: корректность фрейма PING (пустой и с payload под маской), исключение при закрытом сокете, цикл шлёт пинги повторно / чисто отменяется / выходит при ошибке отправки / отключён при interval<=0.

