### PR TITLE
Добавлена сборка Windows ARM64 в Build & Release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,9 @@ jobs:
 
   build-windows-arm64:
     runs-on: windows-11-arm
+    env:
+      CRYPTOGRAPHY_VERSION: "46.0.5"
+      ARM64_WHEELHOUSE: wheelhouse-arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -89,7 +92,15 @@ jobs:
           architecture: arm64
           cache: "pip"
 
+      - name: Restore ARM64 cryptography wheel
+        id: cryptography-wheel-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ARM64_WHEELHOUSE }}
+          key: windows-arm64-py311-cryptography-${{ env.CRYPTOGRAPHY_VERSION }}-${{ hashFiles('pyproject.toml', '.github/workflows/build.yml') }}
+
       - name: Install ARM64 OpenSSL
+        if: steps.cryptography-wheel-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           vcpkg install openssl:arm64-windows-static
@@ -98,8 +109,14 @@ jobs:
           "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
           "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
 
+      - name: Build ARM64 cryptography wheel
+        if: steps.cryptography-wheel-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir $env:ARM64_WHEELHOUSE
+          pip wheel --no-deps --wheel-dir $env:ARM64_WHEELHOUSE "cryptography==$env:CRYPTOGRAPHY_VERSION"
+
       - name: Install dependencies & pyinstaller
-        run: pip install . "pyinstaller==6.13.0"
+        run: pip install --find-links $env:ARM64_WHEELHOUSE . "pyinstaller==6.13.0"
 
       - name: Build EXE with PyInstaller
         run: pyinstaller packaging/windows.spec --noconfirm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ permissions:
   contents: write
 
 jobs:
-  build-windows:
+  build-windows-x64:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -68,13 +68,72 @@ jobs:
           "
 
       - name: Rename artifact
-        run: mv dist/TgWsProxy.exe dist/TgWsProxy_windows.exe
+        run: mv dist/TgWsProxy.exe dist/TgWsProxy_windows_x64.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: TgWsProxy
-          path: dist/TgWsProxy_windows.exe
+          name: TgWsProxy-windows-x64
+          path: dist/TgWsProxy_windows_x64.exe
+
+  build-windows-arm64:
+    runs-on: windows-11-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          architecture: arm64
+          cache: "pip"
+
+      - name: Install ARM64 OpenSSL
+        shell: pwsh
+        run: |
+          vcpkg install openssl:arm64-windows-static
+          $opensslDir = "$env:VCPKG_INSTALLATION_ROOT\installed\arm64-windows-static"
+          "OPENSSL_DIR=$opensslDir" >> $env:GITHUB_ENV
+          "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
+
+      - name: Install dependencies & pyinstaller
+        run: pip install . "pyinstaller==6.13.0"
+
+      - name: Build EXE with PyInstaller
+        run: pyinstaller packaging/windows.spec --noconfirm
+
+      - name: Strip Rich PE header
+        shell: bash
+        run: |
+          python -c "
+          import struct, pathlib
+          exe = pathlib.Path('dist/TgWsProxy.exe')
+          data = bytearray(exe.read_bytes())
+          rich = data.find(b'Rich')
+          if rich == -1:
+              print('Rich header not found, skipping')
+              raise SystemExit(0)
+          ck = struct.unpack_from('<I', data, rich + 4)[0]
+          dans = struct.pack('<I', 0x536E6144 ^ ck)
+          ds = data.find(dans)
+          if ds == -1:
+              print('DanS marker not found, skipping')
+              raise SystemExit(0)
+          data[ds:rich + 8] = b'\x00' * (rich + 8 - ds)
+          exe.write_bytes(data)
+          print(f'Stripped Rich header: offset {ds}..{rich+8}')
+          "
+
+      - name: Rename artifact
+        run: mv dist/TgWsProxy.exe dist/TgWsProxy_windows_arm64.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: TgWsProxy-windows-arm64
+          path: dist/TgWsProxy_windows_arm64.exe
 
   build-win7:
     runs-on: windows-latest
@@ -439,7 +498,7 @@ jobs:
             dist/TgWsProxy_linux_amd64.rpm
 
   release:
-    needs: [build-windows, build-win7, build-macos, build-linux]
+    needs: [build-windows-x64, build-windows-arm64, build-win7, build-macos, build-linux]
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.make_release == 'true' }}
     steps:
@@ -462,7 +521,8 @@ jobs:
             > Не можете скачать?
             > Добавьте `185.199.109.133 release-assets.githubusercontent.com` в hosts или воспользуйтесь зеркалом: https://sourceforge.net/projects/tg-ws-proxy.mirror/files/
           files: |
-            dist/TgWsProxy_windows.exe
+            dist/TgWsProxy_windows_x64.exe
+            dist/TgWsProxy_windows_arm64.exe
             dist/TgWsProxy_windows_7_64bit.exe
             dist/TgWsProxy_windows_7_32bit.exe
             dist/TgWsProxy_macos_universal.dmg

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,8 @@
 
 Перейдите на [страницу релизов](https://github.com/Flowseal/tg-ws-proxy/releases) и скачайте:
 
-- `TgWsProxy_windows.exe` (Windows 10+)
+- `TgWsProxy_windows_x64.exe` (Windows 10+ x64)
+- `TgWsProxy_windows_arm64.exe` (Windows 10+ ARM64)
 - `TgWsProxy_windows_7_64bit.exe` (Windows 7 x64)
 - `TgWsProxy_windows_7_32bit.exe` (Windows 7 x32)
 
@@ -116,7 +117,8 @@ Telegram Desktop → MTProto Proxy (127.0.0.1:1443) → WebSocket → Telegram D
 
 Минимально поддерживаемые версии ОС для текущих бинарных сборок:
 
-- Windows 10+ для `TgWsProxy_windows.exe`
+- Windows 10+ x64 для `TgWsProxy_windows_x64.exe`
+- Windows 10+ ARM64 для `TgWsProxy_windows_arm64.exe`
 - Windows 7 (x64) для `TgWsProxy_windows_7_64bit.exe`
 - Windows 7 (x32) для `TgWsProxy_windows_7_32bit.exe`
 - Intel macOS 10.15+

--- a/docs/README.windows.md
+++ b/docs/README.windows.md
@@ -2,7 +2,8 @@
 
 Перейдите на [страницу релизов](https://github.com/Flowseal/tg-ws-proxy/releases) и скачайте:
 
-- `TgWsProxy_windows.exe` (Windows 10+)
+- `TgWsProxy_windows_x64.exe` (Windows 10+ x64)
+- `TgWsProxy_windows_arm64.exe` (Windows 10+ ARM64)
 - `TgWsProxy_windows_7_64bit.exe` (Windows 7 x64)
 - `TgWsProxy_windows_7_32bit.exe` (Windows 7 x32)
 


### PR DESCRIPTION
**Дополнительно со всеми раннерами в workflow компилирует TgWsProxy на windows arm64.**

При работе скачивает дополнительно OpenSSL для билда зависимости "cryptography" из исходников, ведь у неё нету готовой, собранной arm64 версии. 

**Занимает весь билд, arm64 версии tgwsproxy, около 9 минут.**

На windows arm64 есть конечно ретранслятор с x64 на arm64 но всё же  потеря производительности есть, а в таком случае будет всё работать нативно, никаких багов приложения не заметил, пока им пользовался на устройстве с arm64 процессором, сам телеграмм также поддерживает эту архитектуру поэтому и сам телеграмм, и сам локальный прокси работают быстро.

Артефакт TwWsProxy с внутренним TgWsProxy_windows переименованы дабы не было небольшой путаницы,  оба теперь называются TgWsProxy-windows-x64 (у самого exe вместо дефисов - нижние подчёркивания в названии)