### PR TITLE
Портативный режим для Windows

### DIFF
--- a/utils/tray_common.py
+++ b/utils/tray_common.py
@@ -25,10 +25,14 @@ APP_NAME = "TgWsProxy"
 
 def _app_dir() -> Path:
     if sys.platform == "win32":
-        return Path(os.environ.get("APPDATA", Path.home())) / APP_NAME
-    if sys.platform == "darwin":
+        if bool(getattr(sys, "frozen", False)):
+            return Path(sys.executable).parent / APP_NAME
+        else:
+            return Path(__file__).resolve().parent.parent / APP_NAME
+    elif sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support" / APP_NAME
-    return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / APP_NAME
+    else:
+        return Path.home() / ".config" / APP_NAME
 
 
 APP_DIR = _app_dir()

--- a/windows.py
+++ b/windows.py
@@ -68,10 +68,17 @@ _ERROR_ALREADY_EXISTS = 183
 def _acquire_win_mutex() -> bool | None:
     global _win_mutex_handle
     try:
+        import hashlib
+        if bool(getattr(sys, "frozen", False)):
+            exe_path = str(Path(sys.executable).parent)
+        else:
+            exe_path = str(Path(__file__).resolve().parent)
+        folder_hash = hashlib.md5(exe_path.encode()).hexdigest()[:8]
+        mutex_name = f"Local\\TgWsProxy_{folder_hash}"
         kernel32 = ctypes.windll.kernel32
         kernel32.CreateMutexW.restype = ctypes.c_void_p
         kernel32.CreateMutexW.argtypes = [ctypes.c_void_p, ctypes.c_bool, ctypes.c_wchar_p]
-        handle = kernel32.CreateMutexW(None, True, "Local\\TgWsProxy_SingleInstance")
+        handle = kernel32.CreateMutexW(None, True, mutex_name)
         if kernel32.GetLastError() == _ERROR_ALREADY_EXISTS:
             kernel32.CloseHandle(ctypes.c_void_p(handle))
             return False


### PR DESCRIPTION
1. В `utils/tray_common.py` функция `_app_dir()` теперь проверяет флаг `sys.frozen`. Файлы конфигурации `config.json` и логи `proxy.log` автоматически сохраняются в подпапку `TgWsProxy` рядом с исполняемым файлом, а не уходят в `%APPDATA%`. Поведение для macOS и Linux оставлено без изменений.
2. В `windows.py` имя системного мутекса защиты от повторного запуска теперь динамически зависит от хэша пути папки запуска (`Local\TgWsProxy_{folder_hash}`). Это позволяет полностью изолировать портативные сборки и запускать несколько копий программы из разных директорий одновременно (например, на разных портах).