### PR TITLE
Полный переход на CTk-диалоги с поддержкой темной/светлой темы & Исправление белой темы в подсказках (тулпитах) в трей-настройках

### DIFF
--- a/ui/ctk_dialogs.py
+++ b/ui/ctk_dialogs.py
@@ -1,0 +1,447 @@
+import io
+import base64
+import tkinter as tk
+from enum import Enum
+from typing import Any, Optional, Sequence, Tuple
+
+from ui.ctk_theme import CtkTheme, center_ctk_geometry, resolve_ctk_color
+
+class DialogKind(str, Enum):
+    INFO = "info"
+    ERROR = "error"
+    QUESTION = "question"
+
+def _clear_low_alpha(image: Any, threshold: int = 72) -> Any:
+    alpha = image.getchannel("A")
+    mask = alpha.point(lambda value: 0 if value < threshold else value)
+    image.putalpha(mask)
+    return image
+
+def _modern_dialog_icon(kind: DialogKind, size: int = 40):
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+    except Exception:
+        return None
+
+    scale = 4
+    canvas = size * scale
+    img = Image.new("RGBA", (canvas, canvas), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    fill = (217, 52, 52, 255) if kind == DialogKind.ERROR else (51, 144, 236, 255)
+    pad = max(4, int(canvas * 0.08))
+    draw.ellipse((pad, pad, canvas - pad - 1, canvas - pad - 1), fill=fill)
+    text = "?" if kind == DialogKind.QUESTION else "i" if kind == DialogKind.INFO else "!"
+    try:
+        font_name = "segoeuib.ttf" if kind == DialogKind.ERROR else "segoeui.ttf"
+        font = ImageFont.truetype(font_name, int(canvas * 0.68))
+    except Exception:
+        font = ImageFont.load_default()
+        
+    if kind == DialogKind.ERROR:
+        line = max(6, int(canvas * 0.13))
+        inset = int(canvas * 0.31)
+        draw.line((inset, inset, canvas - inset, canvas - inset), fill=(255, 255, 255, 255), width=line)
+        draw.line((canvas - inset, inset, inset, canvas - inset), fill=(255, 255, 255, 255), width=line)
+    else:
+        bbox = draw.textbbox((0, 0), text, font=font)
+        x = (canvas - (bbox[2] - bbox[0])) / 2 - bbox[0]
+        y = (canvas - (bbox[3] - bbox[1])) / 2 - bbox[1] + canvas * 0.01
+        draw.text((x, y), text, font=font, fill=(255, 255, 255, 255))
+        
+    return _clear_low_alpha(img.resize((size, size), Image.Resampling.LANCZOS), 48)
+
+def _photo_from_image(image: Any) -> Any:
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    data = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return tk.PhotoImage(data=data)
+
+
+def _build_dialog_base(
+    ctk: Any,
+    parent: Optional[Any],
+    theme: CtkTheme,
+    title: str,
+    message: str,
+    kind: DialogKind,
+    icon_path: Optional[str]
+) -> Tuple[Any, Any, Any, float]:
+    body_bg = resolve_ctk_color(ctk, theme.bg)
+    text_color = theme.text_primary
+
+    root = ctk.CTkToplevel(parent)
+    root.withdraw()
+    root.title(title)
+    root.configure(fg_color=body_bg)
+    
+    if parent is not None:
+        try:
+            root.transient(parent)
+        except Exception:
+            pass
+            
+    try:
+        root.attributes("-topmost", True)
+    except Exception:
+        pass
+
+    if icon_path:
+        try:
+            root.after(300, lambda: root.iconbitmap(icon_path))
+        except Exception:
+            pass
+
+    body = ctk.CTkFrame(root, fg_color=body_bg, corner_radius=0)
+    body.pack(fill="both", expand=True, padx=20, pady=16)
+    
+    try:
+        scaling = ctk.ScalingTracker.get_window_scaling(root)
+    except Exception:
+        scaling = root._get_window_scaling() if hasattr(root, "_get_window_scaling") else 1.0
+    icon_size_scaled = int(40 * scaling)
+
+    pil_icon = _modern_dialog_icon(kind, size=icon_size_scaled)
+    if pil_icon is not None:
+        tk_icon = _photo_from_image(pil_icon)
+        icon_label = tk.Label(
+            body,
+            text="",
+            image=tk_icon,
+            width=icon_size_scaled,
+            height=icon_size_scaled,
+            bg=body_bg,
+            bd=0,
+            highlightthickness=0
+        )
+        icon_label.image = tk_icon # keep reference
+        icon_label.pack(side="left", anchor="n", padx=(0, int(14 * scaling)))
+    else:
+        icon_label = None
+    
+    content_frame = ctk.CTkFrame(body, fg_color="transparent")
+    content_frame.pack(side="left", fill="both", expand=True)
+
+    text_label = ctk.CTkLabel(
+        content_frame,
+        text=message,
+        justify="left",
+        anchor="nw",
+        font=(theme.ui_font_family, 13),
+        text_color=text_color,
+        wraplength=int(350 * scaling),
+    )
+    text_label.pack(fill="x")
+    
+    # Dynamic Alignment Logic
+    dummy = ctk.CTkLabel(content_frame, text="A", font=(theme.ui_font_family, 13))
+    dummy.pack()
+    root.update_idletasks()
+    
+    line_h = dummy.winfo_reqheight()
+    dummy.destroy()
+    root.update_idletasks()
+    
+    text_h = text_label.winfo_reqheight()
+    icon_h = icon_size_scaled
+    
+    num_lines = max(1, round(text_h / line_h))
+    
+    icon_top_pad = 0
+    text_top_pad = 0
+    
+    if num_lines <= 2:
+        if icon_h > text_h:
+            text_top_pad = (icon_h - text_h) // 2
+        else:
+            icon_top_pad = (text_h - icon_h) // 2
+    else:
+        two_lines_h = line_h * 2
+        if icon_h > two_lines_h:
+            text_top_pad = (icon_h - two_lines_h) // 2
+        else:
+            icon_top_pad = (two_lines_h - icon_h) // 2
+
+    if icon_label is not None and icon_top_pad > 0:
+        icon_label.pack_configure(pady=(icon_top_pad, 0))
+    if text_top_pad > 0:
+        text_label.pack_configure(pady=(text_top_pad, 0))
+    
+    return root, body, content_frame, scaling
+
+def show_ctk_dialog(
+    ctk: Any,
+    *,
+    parent: Optional[Any],
+    theme: CtkTheme,
+    title: str,
+    message: str,
+    kind: DialogKind = DialogKind.INFO,
+    buttons: Sequence[Tuple[str, str, bool]] = (("OK", "ok", True),),
+    default: str = "ok",
+    icon_path: Optional[str] = None,
+) -> str:
+    root, body, content_frame, scaling = _build_dialog_base(ctk, parent, theme, title, message, kind, icon_path)
+    
+    footer_bg = resolve_ctk_color(ctk, theme.field_bg)
+
+    footer = ctk.CTkFrame(root, fg_color=footer_bg, corner_radius=0)
+    footer.pack(fill="x", side="bottom")
+    
+    btn_frame = ctk.CTkFrame(footer, fg_color="transparent")
+    btn_frame.pack(side="right", padx=16, pady=10)
+    
+    result = {"value": default}
+    
+    def close(value: str) -> None:
+        result["value"] = value
+        try:
+            root.grab_release()
+        except Exception:
+            pass
+        root.destroy()
+
+    for i, (text, value, is_primary) in enumerate(buttons):
+        btn = ctk.CTkButton(
+            btn_frame,
+            text=text,
+            width=84,
+            height=28,
+            font=(theme.ui_font_family, 13),
+            corner_radius=8,
+            fg_color=theme.tg_blue if is_primary else theme.field_bg,
+            hover_color=theme.tg_blue_hover if is_primary else theme.field_border,
+            text_color="#ffffff" if is_primary else theme.text_primary,
+            border_width=0 if is_primary else 1,
+            border_color=theme.field_border,
+            command=lambda v=value: close(v)
+        )
+        btn.pack(side="left", padx=(0 if i == 0 else 8, 0))
+        if value == default:
+            try:
+                btn.focus_set()
+            except Exception:
+                pass
+
+    root.protocol("WM_DELETE_WINDOW", lambda: close(default))
+    root.bind("<Escape>", lambda _e: close(default))
+    root.bind("<Return>", lambda _e: close(default))
+    
+    root.update_idletasks()
+    width = max(260, int(root.winfo_reqwidth() / scaling))
+    height = int(root.winfo_reqheight() / scaling)
+    center_ctk_geometry(root, width, height)
+    root.resizable(False, False)
+    root.deiconify()
+    
+    try:
+        root.grab_set()
+    except Exception:
+        pass
+        
+    root.wait_window()
+    return result["value"]
+
+def ask_yes_no(
+    ctk: Any,
+    *,
+    parent: Optional[Any],
+    theme: CtkTheme,
+    title: str,
+    message: str,
+    icon_path: Optional[str] = None,
+) -> bool:
+    return show_ctk_dialog(
+        ctk,
+        parent=parent,
+        theme=theme,
+        title=title,
+        message=message,
+        kind=DialogKind.QUESTION,
+        buttons=(("Да", "yes", True), ("Нет", "no", False)),
+        default="no",
+        icon_path=icon_path,
+    ) == "yes"
+
+def show_error(
+    ctk: Any,
+    *,
+    parent: Optional[Any],
+    theme: CtkTheme,
+    title: str,
+    message: str,
+    icon_path: Optional[str] = None,
+) -> bool:
+    show_ctk_dialog(
+        ctk,
+        parent=parent,
+        theme=theme,
+        title=title,
+        message=message,
+        kind=DialogKind.ERROR,
+        buttons=(("OK", "ok", True),),
+        icon_path=icon_path,
+    )
+    return True
+
+def show_info(
+    ctk: Any,
+    *,
+    parent: Optional[Any],
+    theme: CtkTheme,
+    title: str,
+    message: str,
+    icon_path: Optional[str] = None,
+) -> bool:
+    show_ctk_dialog(
+        ctk,
+        parent=parent,
+        theme=theme,
+        title=title,
+        message=message,
+        kind=DialogKind.INFO,
+        buttons=(("OK", "ok", True),),
+        icon_path=icon_path,
+    )
+    return True
+
+def run_with_progress(
+    ctk: Any,
+    *,
+    parent: Optional[Any],
+    theme: CtkTheme,
+    title: str,
+    message: str,
+    icon_path: Optional[str] = None,
+    task: Any,
+) -> str:
+    import queue as _queue
+    import threading as _threading
+
+    root, body, content_frame, scaling = _build_dialog_base(ctk, parent, theme, title, message, DialogKind.INFO, icon_path)
+    
+    body.pack_configure(pady=(16, 26))
+
+    status_label = ctk.CTkLabel(
+        content_frame, text="",
+        justify="left", anchor="w",
+        font=(theme.ui_font_family, 11),
+        text_color=theme.text_secondary,
+        wraplength=int(350 * scaling),
+    )
+    status_label.pack(fill="x", pady=(6, 0))
+
+    footer = ctk.CTkFrame(root, fg_color=theme.field_bg, corner_radius=0)
+    footer.pack(fill="x", side="bottom")
+
+    btn_frame = ctk.CTkFrame(footer, fg_color="transparent")
+    btn_frame.pack(side="right", padx=16, pady=10)
+
+    result = {"value": "close"}
+    running = {"value": False}
+    buttons = []
+    task_events = _queue.Queue()
+
+    def close(value: str) -> None:
+        if running["value"]:
+            return
+        result["value"] = value
+        try:
+            root.grab_release()
+        except Exception:
+            pass
+        root.destroy()
+
+    def _set_running(value: bool) -> None:
+        running["value"] = value
+        state = "disabled" if value else "normal"
+        for btn in buttons:
+            btn.configure(state=state)
+        root.protocol("WM_DELETE_WINDOW", lambda: None if value else close("close"))
+
+    def _finish_task() -> None:
+        _set_running(False)
+
+    def _set_status(msg: str) -> None:
+        task_events.put(("status", msg))
+
+    def _poll_task_events() -> None:
+        while True:
+            try:
+                event, value = task_events.get_nowait()
+            except _queue.Empty:
+                break
+            if event == "status":
+                status_label.configure(text=value)
+            elif event == "finish":
+                _finish_task()
+
+        if running["value"]:
+            root.after(50, _poll_task_events)
+
+    def _run_task() -> None:
+        try:
+            task(_set_status)
+        except Exception as exc:
+            _set_status(f"Ошибка: {exc}")
+        finally:
+            task_events.put(("finish", ""))
+
+    def _on_update() -> None:
+        _set_running(True)
+        _poll_task_events()
+        _threading.Thread(target=_run_task, daemon=True).start()
+
+    btn_update = ctk.CTkButton(
+        btn_frame,
+        text="Обновить",
+        width=88,
+        height=34,
+        font=(theme.ui_font_family, 13),
+        command=_on_update,
+    )
+    btn_update.pack(side="left", padx=(0, 6))
+    buttons.append(btn_update)
+
+    btn_page = ctk.CTkButton(
+        btn_frame,
+        text="Страница",
+        width=88,
+        height=34,
+        font=(theme.ui_font_family, 13),
+        command=lambda: close("open"),
+    )
+    btn_page.pack(side="left", padx=(0, 6))
+    buttons.append(btn_page)
+
+    btn_close = ctk.CTkButton(
+        btn_frame,
+        text="Закрыть",
+        width=88,
+        height=34,
+        font=(theme.ui_font_family, 13),
+        fg_color=theme.field_bg,
+        hover_color=theme.field_border,
+        text_color=theme.text_primary,
+        border_width=1,
+        border_color=theme.field_border,
+        command=lambda: close("close"),
+    )
+    btn_close.pack(side="left")
+    buttons.append(btn_close)
+
+    root.protocol("WM_DELETE_WINDOW", lambda: close("close"))
+
+    root.update_idletasks()
+    width = max(320, int(root.winfo_reqwidth() / scaling))
+    height = int(root.winfo_reqheight() / scaling)
+    center_ctk_geometry(root, width, height)
+    root.resizable(False, False)
+    root.deiconify()
+
+    try:
+        root.grab_set()
+    except Exception:
+        pass
+
+    root.wait_window()
+    return result["value"]

--- a/ui/ctk_theme.py
+++ b/ui/ctk_theme.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import tkinter
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 _tk_variable_del_guard_installed = False
 
@@ -57,6 +57,19 @@ _APPEARANCE_MODE_MAP = {"auto": "system", "light": "Light", "dark": "Dark"}
 def apply_ctk_appearance(ctk: Any, mode: str = "auto") -> None:
     ctk.set_appearance_mode(_APPEARANCE_MODE_MAP.get(mode, "system"))
     ctk.set_default_color_theme("blue")
+
+
+def is_dark_mode(ctk: Any) -> bool:
+    try:
+        return str(ctk.get_appearance_mode()).lower() == "dark"
+    except Exception:
+        return False
+
+
+def resolve_ctk_color(ctk: Any, color: Union[str, Tuple[str, str]]) -> str:
+    if isinstance(color, tuple):
+        return color[1] if is_dark_mode(ctk) else color[0]
+    return color
 
 def center_ctk_geometry(root: Any, width: int, height: int) -> None:
     sw = root.winfo_screenwidth()

--- a/ui/ctk_tooltip.py
+++ b/ui/ctk_tooltip.py
@@ -54,18 +54,25 @@ class CtkTooltip:
             tw.wm_attributes("-topmost", True)
         except Exception:
             pass
-        tw.configure(fg_color="#2b2b2b")
+        from ui.ctk_theme import ctk_theme_for_platform, resolve_ctk_color
+
+        theme = ctk_theme_for_platform()
+        bg_color = resolve_ctk_color(ctk, theme.field_bg)
+        fg_color = resolve_ctk_color(ctk, theme.text_primary)
+        bd_color = resolve_ctk_color(ctk, theme.field_border)
+
+        tw.configure(fg_color=bd_color)
         lbl = ctk.CTkLabel(
             tw,
             text=self.text,
             justify="left",
             wraplength=self.wraplength,
-            fg_color="#2b2b2b",
-            text_color="#f0f0f0",
+            fg_color=bg_color,
+            text_color=fg_color,
             corner_radius=0,
-            font=("Segoe UI", 14) if _is_windows() else None,
+            font=(theme.ui_font_family, 14),
         )
-        lbl.pack(padx=10, pady=8)
+        lbl.pack(padx=1, pady=1, ipadx=10, ipady=8)
         x = self.widget.winfo_rootx() + 12
         y = self.widget.winfo_rooty() + self.widget.winfo_height() + 4
         tw.wm_geometry(f"+{x}+{y}")

--- a/ui/ctk_tray_ui.py
+++ b/ui/ctk_tray_ui.py
@@ -14,8 +14,10 @@ from utils.update_check import RELEASES_PAGE_URL, get_status
 from ui.ctk_theme import (
     FIRST_RUN_FRAME_PAD,
     CtkTheme,
+    ctk_theme_for_platform,
     main_content_frame,
 )
+from ui.ctk_dialogs import show_info as ctk_show_info
 from ui.ctk_tooltip import attach_ctk_tooltip, attach_tooltip_to_widgets
 from ui.i18n import (
     label_from_language,
@@ -136,9 +138,6 @@ def _show_connectivity_results(title_base: str, results: dict,
                                domain: str = '', label_prefix: str = 'DC',
                                auto_mode: bool = False,
                                unavailable_message: str = '') -> None:
-    import tkinter as _tk
-    from tkinter import messagebox as _mb
-
     ok = [dc for dc, v in results.items() if v is True]
     total = len(_CFPROXY_TEST_DCS)
     if auto_mode:
@@ -169,21 +168,11 @@ def _show_connectivity_results(title_base: str, results: dict,
             )
             msg = t("connectivity.partial_detail", domain=domain, ok_list=ok_list, fail_list=fail_list)
 
-    root = _tk.Tk()
-    root.withdraw()
-    try:
-        root.attributes("-topmost", True)
-    except Exception:
-        pass
-    _mb.showinfo(title, msg, parent=root)
-    root.destroy()
+    _show_ctk_info(title, msg)
 
 
 def _show_multi_connectivity_results(title_base: str, per_domain: dict,
                                      label_prefix: str = 'DC') -> None:
-    import tkinter as _tk
-    from tkinter import messagebox as _mb
-
     total = len(_CFPROXY_TEST_DCS)
     all_ok = True
     any_ok = False
@@ -214,14 +203,50 @@ def _show_multi_connectivity_results(title_base: str, per_domain: dict,
         title = t("connectivity.unavailable", title=title_base)
     msg = "\n\n".join(blocks)
 
-    root = _tk.Tk()
-    root.withdraw()
+    _show_ctk_info(title, msg)
+
+
+def _show_ctk_info(title: str, message: str) -> None:
     try:
-        root.attributes("-topmost", True)
+        import customtkinter as ctk
+        import threading
+        from utils.tray_common import APP_ICON_PATH, ctk_run_dialog, ensure_ctk_thread, is_ctk_thread
+
+        if ensure_ctk_thread(ctk, "auto"):
+            if is_ctk_thread():
+                ctk_show_info(
+                    ctk,
+                    parent=None,
+                    theme=ctk_theme_for_platform(),
+                    title=title,
+                    message=message,
+                    icon_path=APP_ICON_PATH,
+                )
+            else:
+                def _build(done: threading.Event) -> None:
+                    ctk_show_info(
+                        ctk,
+                        parent=None,
+                        theme=ctk_theme_for_platform(),
+                        title=title,
+                        message=message,
+                        icon_path=APP_ICON_PATH,
+                    )
+                    done.set()
+                ctk_run_dialog(_build)
+            return
+    except Exception:
+        log.exception("CTk connectivity result dialog failed")
+        
+    try:
+        import tkinter as _tk
+        from tkinter import messagebox as _mb
+        root = _tk.Tk()
+        root.withdraw()
+        _mb.showinfo(title, message, parent=root)
+        root.destroy()
     except Exception:
         pass
-    _mb.showinfo(title, msg, parent=root)
-    root.destroy()
 
 _INNER_W = 396
 

--- a/utils/tray_common.py
+++ b/utils/tray_common.py
@@ -24,6 +24,12 @@ log = logging.getLogger("tg-ws-tray")
 
 APP_NAME = "TgWsProxy"
 PORTABLE_DIR_NAME = "TgWsProxy_data"
+APP_ICON_PATH = str(Path(__file__).parents[1] / "icon.ico")
+CTK_THREAD_NAME = "ctk-root"
+
+
+def is_ctk_thread() -> bool:
+    return threading.current_thread().name == CTK_THREAD_NAME
 
 
 def _standard_app_dir() -> Path:
@@ -290,7 +296,7 @@ def _font_paths():
 def load_icon():
     from PIL import Image
 
-    icon_path = Path(__file__).parents[1] / "icon.ico"
+    icon_path = Path(APP_ICON_PATH)
     if icon_path.exists():
         try:
             return Image.open(str(icon_path))
@@ -513,7 +519,7 @@ def ensure_ctk_thread(ctk: Any, mode: str = "auto") -> bool:
         _ctk_root_ready.set()
         _ctk_root.mainloop()
 
-    threading.Thread(target=_run, daemon=True, name="ctk-root").start()
+    threading.Thread(target=_run, daemon=True, name=CTK_THREAD_NAME).start()
     _ctk_root_ready.wait(timeout=5.0)
     return _ctk_root is not None
 

--- a/windows.py
+++ b/windows.py
@@ -41,9 +41,9 @@ from utils.win32_theme import (
     apply_windows_dark_theme,
 )
 from utils.tray_common import (
-    APP_NAME, DEFAULT_CONFIG, FIRST_RUN_MARKER, IS_FROZEN, LOG_FILE,
+    APP_ICON_PATH, APP_NAME, DEFAULT_CONFIG, FIRST_RUN_MARKER, IS_FROZEN, LOG_FILE,
     acquire_lock, bootstrap, check_ipv6_warning, ctk_run_dialog,
-    ensure_ctk_thread, ensure_dirs, load_config, load_icon, log,
+    ensure_ctk_thread, ensure_dirs, is_ctk_thread, load_config, load_icon, log,
     quit_ctk, release_lock, restart_proxy,
     save_config, start_proxy, stop_proxy, tg_proxy_url,
 )
@@ -51,6 +51,13 @@ from ui.ctk_tray_ui import (
     install_tray_config_buttons, install_tray_config_form,
     populate_first_run_window, tray_settings_scroll_and_footer,
     validate_config_form,
+)
+from ui.ctk_dialogs import (
+    ask_yes_no as ctk_ask_yes_no,
+    run_with_progress as ctk_run_with_progress,
+    show_ctk_dialog,
+    show_error as ctk_show_error,
+    show_info as ctk_show_info,
 )
 from ui.ctk_theme import (
     CONFIG_DIALOG_FRAME_PAD, CONFIG_DIALOG_SIZE, FIRST_RUN_SIZE,
@@ -95,7 +102,7 @@ def _release_win_mutex() -> None:
             pass
         _win_mutex_handle = None
 
-ICON_PATH = str(Path(__file__).parent / "icon.ico")
+ICON_PATH = APP_ICON_PATH
 
 # win32 dialogs
 
@@ -111,16 +118,62 @@ _IDYES = 6
 _IDNO = 7
 
 
+def _run_ctk_modal(callback):
+    if ctk is not None and ensure_ctk_thread(ctk, _config.get("appearance", "auto")):
+        if is_ctk_thread():
+            return callback()
+
+        result = {"value": None}
+        def _build(done: threading.Event) -> None:
+            result["value"] = callback()
+            done.set()
+
+        ctk_run_dialog(_build)
+        return result["value"]
+    return None
+
+
 def _show_error(text: str, title: Optional[str] = None) -> None:
-    _u32.MessageBoxW(None, text, title or t("app.error_title"), _MB_OK_ERR)
+    _title = title or t("app.error_title")
+    if _run_ctk_modal(lambda: ctk_show_error(
+        ctk,
+        parent=None,
+        theme=ctk_theme_for_platform(),
+        title=_title,
+        message=text,
+        icon_path=ICON_PATH,
+    )):
+        return
+    _u32.MessageBoxW(None, text, _title, _MB_OK_ERR)
 
 
 def _show_info(text: str, title: Optional[str] = None) -> None:
-    _u32.MessageBoxW(None, text, title or t("app.name"), _MB_OK_INFO)
+    _title = title or t("app.name")
+    if _run_ctk_modal(lambda: ctk_show_info(
+        ctk,
+        parent=None,
+        theme=ctk_theme_for_platform(),
+        title=_title,
+        message=text,
+        icon_path=ICON_PATH,
+    )):
+        return
+    _u32.MessageBoxW(None, text, _title, _MB_OK_INFO)
 
 
 def _ask_yes_no(text: str, title: Optional[str] = None) -> bool:
-    return _u32.MessageBoxW(None, text, title or t("app.name"), _MB_YESNO_Q) == _IDYES
+    _title = title or t("app.name")
+    result = _run_ctk_modal(lambda: ctk_ask_yes_no(
+        ctk,
+        parent=None,
+        theme=ctk_theme_for_platform(),
+        title=_title,
+        message=text,
+        icon_path=ICON_PATH,
+    ))
+    if result is not None:
+        return bool(result)
+    return _u32.MessageBoxW(None, text, _title, _MB_YESNO_Q) == _IDYES
 
 
 def update_ctk_form(
@@ -131,99 +184,54 @@ def update_ctk_form(
     if ctk is None or not ensure_ctk_thread(ctk, _config.get("appearance", "auto")):
         result = _u32.MessageBoxW(None, text, title, _MB_YESNOCANCEL_Q)
         if result == _IDYES:
+            if download_url:
+                _perform_update(download_url)
+                return "close"
             return "update"
         if result == _IDNO:
             return "open"
         return "close"
 
-    result = {"value": "close"}
-
-    def _build(done: threading.Event) -> None:
+    def _show_update_dialog() -> str:
         theme = ctk_theme_for_platform()
-        root = create_ctk_toplevel(
-            ctk,
-            title=title,
-            width=310 if IS_FROZEN else 210,
-            height=130 if IS_FROZEN else 100,
-            theme=theme,
-            after_create=lambda r: r.iconbitmap(ICON_PATH),
-        )
-        frame = main_content_frame(ctk, root, theme, padx=16, pady=14)
+        if IS_FROZEN and download_url:
+            def _do_update(set_status):
+                return _perform_update(download_url, set_status=set_status)
 
-        ctk.CTkLabel(
-            frame,
-            text=text,
-            justify="left",
-            anchor="w",
-            wraplength=270,
-            font=(theme.ui_font_family, 12),
-            text_color=theme.text_primary,
-        ).pack(fill="x", pady=(0, 10))
-
-        row = ctk.CTkFrame(frame, fg_color="transparent")
-        row.pack(fill="x")
-
-        status_label = ctk.CTkLabel(
-            frame, text="", justify="left", anchor="w", wraplength=270,
-            font=(theme.ui_font_family, 11), text_color=theme.text_secondary,
-        )
-        status_label.pack(fill="x", pady=(6, 0))
-
-        btns: list = []
-
-        def _set_status(msg: str) -> None:
-            root.after(0, lambda: status_label.configure(text=msg))
-
-        def _close_with(value: str) -> None:
-            result["value"] = value
-            root.destroy()
-            done.set()
-
-        def _on_update() -> None:
-            if not download_url:
-                if release_url:
-                    webbrowser.open(release_url)
-                _close_with("open")
-                return
-            for b in btns:
-                b.configure(state="disabled")
-            root.protocol("WM_DELETE_WINDOW", lambda: None)
-            def _run():
-                _perform_update(download_url, set_status=_set_status)
-                root.after(0, lambda: [b.configure(state="normal") for b in btns])
-                root.after(0, lambda: root.protocol("WM_DELETE_WINDOW", lambda: _close_with("close")))
-            threading.Thread(target=_run, daemon=True).start()
-
-        if IS_FROZEN:
-            btn_upd = ctk.CTkButton(
-                row, text=t("button.update"), width=88, height=34,
-                font=(theme.ui_font_family, 13), command=_on_update,
+            return ctk_run_with_progress(
+                ctk,
+                parent=None,
+                theme=theme,
+                title=title,
+                message=text,
+                icon_path=ICON_PATH,
+                task=_do_update,
             )
-            btn_upd.pack(side="left", padx=(0, 6))
-            btns.append(btn_upd)
-        btn_pg = ctk.CTkButton(
-            row, text=t("button.page"), width=88, height=34,
-            font=(theme.ui_font_family, 13), command=lambda: _close_with("open"),
+
+        buttons = []
+        if IS_FROZEN:
+            buttons.append((t("button.update"), "update", True))
+        buttons.extend(((t("button.page"), "open", True), (t("button.close"), "close", False)))
+        return show_ctk_dialog(
+            ctk,
+            parent=None,
+            title=title,
+            theme=theme,
+            message=text,
+            kind="info",
+            buttons=tuple(buttons),
+            default="close",
+            icon_path=ICON_PATH,
         )
-        btn_pg.pack(side="left", padx=(0, 6))
-        btns.append(btn_pg)
-        btn_cl = ctk.CTkButton(
-            row, text=t("button.close"), width=88, height=34,
-            font=(theme.ui_font_family, 13),
-            fg_color=theme.field_bg, hover_color=theme.field_border,
-            text_color=theme.text_primary, border_width=1, border_color=theme.field_border,
-            command=lambda: _close_with("close"),
-        )
-        btn_cl.pack(side="left")
-        btns.append(btn_cl)
 
-        root.protocol("WM_DELETE_WINDOW", lambda: _close_with("close"))
-
-    ctk_run_dialog(_build)
-    return result["value"]
+    choice = _run_ctk_modal(_show_update_dialog) or "close"
+    if choice == "update" and release_url:
+        webbrowser.open(release_url)
+        return "open"
+    return choice
 
 
-def _perform_update(download_url: str, set_status=None) -> None:
+def _perform_update(download_url: str, set_status=None) -> bool:
     def _step(msg: str) -> None:
         log.info("Update: %s", msg)
         if set_status:
@@ -261,7 +269,7 @@ def _perform_update(download_url: str, set_status=None) -> None:
                 tmp_path.unlink(missing_ok=True)
             except OSError:
                 pass
-        return
+        return False
 
     _step(t("update.replacing"))
     try:
@@ -274,7 +282,7 @@ def _perform_update(download_url: str, set_status=None) -> None:
             tmp_path.unlink(missing_ok=True)
         except OSError:
             pass
-        return
+        return False
 
     try:
         tmp_path.rename(cur_exe)
@@ -288,7 +296,7 @@ def _perform_update(download_url: str, set_status=None) -> None:
             tmp_path.unlink(missing_ok=True)
         except OSError:
             pass
-        return
+        return False
 
     _step(t("update.restarting"))
     _release_win_mutex()
@@ -516,10 +524,16 @@ def _edit_config_dialog() -> None:
             _finish()
 
         def on_save() -> None:
-            from tkinter import messagebox
             merged = validate_config_form(widgets, DEFAULT_CONFIG, include_autostart=_supports_autostart())
             if isinstance(merged, str):
-                messagebox.showerror(t("app.error_title"), merged, parent=root)
+                ctk_show_error(
+                    ctk,
+                    parent=root,
+                    theme=theme,
+                    title=t("app.error_title"),
+                    message=merged,
+                    icon_path=ICON_PATH,
+                )
                 return
 
             merged["force_test_dc"] = _config.get("force_test_dc", DEFAULT_CONFIG["force_test_dc"])
@@ -545,10 +559,13 @@ def _edit_config_dialog() -> None:
                 _finish()
                 return
 
-            do_restart = messagebox.askyesno(
-                t("dialog.restart_title"),
-                t("dialog.restart_body"),
+            do_restart = ctk_ask_yes_no(
+                ctk,
                 parent=root,
+                theme=theme,
+                title=t("dialog.restart_title"),
+                message=t("dialog.restart_body"),
+                icon_path=ICON_PATH,
             )
             _finish()
             if do_restart:


### PR DESCRIPTION
### Добавлен новый модуль - ui/ctk_dialogs.py.

В нем **все функции вызова любых по типу CTk окон**, обычные сообщения - _show_info_, ошибки - _show_error_, вопросы "Да/Нет" - _ask_yes_no_ и окно загрузки обновления с прогрессом - _run_with_progress_ (оно теперь одно из компонентов CTk окон).

В итоге, на Windows (неважно на 11, 10 или 7 винде) это **добавляет полную поддержку темной темы** в программу, теперь включая темную тему, она распространится не только на основное окно трей-настроек, но и **на все диалоговые окна/ошибки/предупреждения и тому подобные окна**.
При этом поддержка светлой темы никуда не исчезла.

Пока что, на всякий случай, если по какой либо причине будет ошибка при отрисовке CTk сообщений, оставлен fallback на стандартные win32 уведомления/диалоги.

Также пофикшен баг, или недочет (не знаю как назвать), когда при включенной светлой теме, подсказки под параметрами в настройках оставались в темной теме.

Если хотите сами протестировать работу проги, можете скачать артефакт из [actions в моем форке](https://github.com/Yan4ik000/tg-ws-proxy/actions/runs/27805072203)


### Скрины:
<img width="446" height="340" alt="29_IPv6_warning" src="https://github.com/user-attachments/assets/4d321b71-9a3c-47fe-b756-3abe60d5d0a5" />
<img width="378" height="221" alt="27_Ошибка_занятости_порта" src="https://github.com/user-attachments/assets/b49c5666-0155-44b7-b51e-60fd29afcc1e" />
<img width="454" height="221" alt="09_Telegram_ссылка_скопирована" src="https://github.com/user-attachments/assets/3bd6cbe5-6c89-4046-9efa-e2c67a4e5ef1" />

(на начало в заголовках не обращайте внимания, я запрашивал уведомления напрямую через скрипт, а не получал их нормальным способом, и из-за этого писалось в начале заголовка - "dlg-X", в обычном использовании выглядит примерно так)
<img width="318" height="169" alt="{6ACF8501-451F-45DE-8D66-A925FBA9242B}" src="https://github.com/user-attachments/assets/218ed5fa-511e-4ef7-860c-cac14921430a" />
<img width="317" height="163" alt="{DA645F35-8F28-4749-99C1-8692090AA97D}" src="https://github.com/user-attachments/assets/f80561c0-f84f-477a-b97e-f5888822e1c2" />

### Исправленное окно подсказок при белой теме:
<img width="418" height="186" alt="{4ACCB3AC-FD11-4D26-9138-419651A67295}" src="https://github.com/user-attachments/assets/6e9b39f0-6b1a-47e3-8001-6511174bfc8a" />