### PR TITLE
fix: replace harmful WS-PING keepalive with selectable TCP/WS/off modes (#1023)

### DIFF
--- a/proxy/bridge.py
+++ b/proxy/bridge.py
@@ -357,15 +357,16 @@ async def bridge_ws_reencrypt(reader, writer, ws: RawWebSocket, label,
 
     tasks = [asyncio.create_task(tcp_to_ws()),
              asyncio.create_task(ws_to_tcp())]
-    keepalive = asyncio.create_task(
-        _ws_keepalive(ws, proxy_config.ws_keepalive_interval))
+    # 'tcp' mode keeps the link warm via SO_KEEPALIVE set at connect time.
+    if proxy_config.keepalive_mode == 'ws':
+        tasks.append(asyncio.create_task(
+            _ws_keepalive(ws, proxy_config.keepalive_interval)))
     try:
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
     finally:
-        keepalive.cancel()
         for t in tasks:
             t.cancel()
-        for t in (*tasks, keepalive):
+        for t in tasks:
             try:
                 await t
             except BaseException:

--- a/proxy/config.py
+++ b/proxy/config.py
@@ -67,7 +67,9 @@ class ProxyConfig:
     cfproxy_worker_domains: List[str] = field(default_factory=list)
     fake_tls_domain: str = ''
     proxy_protocol: bool = False
-    ws_keepalive_interval: float = 30.0
+    # Upstream keepalive: 'tcp' (SO_KEEPALIVE), 'ws' (WebSocket PING), 'off'.
+    keepalive_mode: str = 'tcp'
+    keepalive_interval: float = 30.0
 
 
 proxy_config = ProxyConfig()

--- a/proxy/raw_websocket.py
+++ b/proxy/raw_websocket.py
@@ -1,12 +1,16 @@
 import os
+import sys
 import ssl
 import base64
 import struct
 import asyncio
+import logging
 import socket as _socket
 
 from typing import List, Optional, Tuple
 from .config import proxy_config
+
+log = logging.getLogger('tg-mtproto-proxy')
 
 
 _st_BB = struct.Struct('>BB')
@@ -46,16 +50,52 @@ def _xor_mask(data: bytes, mask: bytes) -> bytes:
             int.from_bytes(mask_rep, 'big')).to_bytes(n, 'big')
 
 
+def _enable_tcp_keepalive(sock, idle: float):
+    """Enable OS-level TCP keepalive (idle in seconds).
+
+    Probes live below TLS, so unlike WebSocket PINGs they are invisible to
+    Telegram and keep NAT mappings warm without tripping a disconnect (#646).
+    """
+    idle = max(1, int(idle))
+    try:
+        sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)
+    except (OSError, AttributeError):
+        return
+    log.debug("TCP keepalive enabled on upstream (idle=%ds)", idle)
+
+    if sys.platform == 'win32':
+        # ioctl args: (onoff, idle_ms, interval_ms); probe count fixed by OS.
+        try:
+            sock.ioctl(_socket.SIO_KEEPALIVE_VALS,
+                       (1, idle * 1000, idle * 1000))
+        except (OSError, AttributeError, ValueError):
+            pass
+        return
+
+    # Linux: TCP_KEEPIDLE/INTVL/CNT. macOS: TCP_KEEPALIVE is the idle time.
+    for opt_name, value in (('TCP_KEEPIDLE', idle),
+                            ('TCP_KEEPALIVE', idle),
+                            ('TCP_KEEPINTVL', idle),
+                            ('TCP_KEEPCNT', 4)):
+        opt = getattr(_socket, opt_name, None)
+        if opt is None:
+            continue
+        try:
+            sock.setsockopt(_socket.IPPROTO_TCP, opt, value)
+        except (OSError, AttributeError):
+            pass
+
+
 def set_sock_opts(transport, buffer_size):
     sock = transport.get_extra_info('socket')
     if sock is None:
         return
-    
+
     try:
         sock.setsockopt(_socket.IPPROTO_TCP, _socket.TCP_NODELAY, 1)
     except (OSError, AttributeError):
         pass
-    
+
     try:
         sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_RCVBUF, buffer_size)
         sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_SNDBUF, buffer_size)
@@ -86,6 +126,10 @@ class RawWebSocket:
             timeout=min(timeout, 10))
         
         set_sock_opts(writer.transport, proxy_config.buffer_size)
+        if proxy_config.keepalive_mode == 'tcp':
+            sock = writer.transport.get_extra_info('socket')
+            if sock is not None:
+                _enable_tcp_keepalive(sock, proxy_config.keepalive_interval)
 
         ws_key = base64.b64encode(os.urandom(16)).decode()
 

--- a/proxy/tg_ws_proxy.py
+++ b/proxy/tg_ws_proxy.py
@@ -489,6 +489,11 @@ async def _run(stop_event: Optional[asyncio.Event] = None):
     if proxy_config.cfproxy_worker_domains:
         log.info("  CF worker:     enabled (%s)",
                  ", ".join(proxy_config.cfproxy_worker_domains))
+    if proxy_config.keepalive_mode == 'off':
+        log.info("  Keepalive:     off")
+    else:
+        log.info("  Keepalive:     %s (%.0fs)",
+                 proxy_config.keepalive_mode, proxy_config.keepalive_interval)
     log.info("=" * 60)
     log.info("  Connect:")
     if ftls:
@@ -593,11 +598,28 @@ def main():
     ap.add_argument('--proxy-protocol', action='store_true',
                     help='Accept PROXY protocol v1 header '
                          '(for use behind nginx/haproxy with proxy_protocol on)')
-    ap.add_argument('--ws-keepalive', type=float, default=30.0, metavar='SEC',
-                    help='Seconds between WebSocket keepalive PINGs to the '
-                         'upstream (default 30, 0 to disable). Keeps idle '
-                         'sessions alive through NAT/firewall timeouts.')
+    ap.add_argument('--keepalive', choices=('off', 'tcp', 'ws'), default='tcp',
+                    help='Upstream keepalive mode (default tcp). "tcp" uses '
+                         'OS-level SO_KEEPALIVE (transparent to Telegram), '
+                         '"ws" sends WebSocket PING frames (legacy; may be '
+                         'closed by /apiws), "off" disables keepalive.')
+    ap.add_argument('--keepalive-interval', type=float, default=30.0,
+                    metavar='SEC',
+                    help='Keepalive idle interval in seconds (default 30). '
+                         'For tcp: idle time before probes; for ws: interval '
+                         'between PINGs. Keeps idle sessions alive through '
+                         'NAT/firewall timeouts (issue #646).')
+    ap.add_argument('--ws-keepalive', type=float, default=None, metavar='SEC',
+                    help='Deprecated alias: sets --keepalive ws with the given '
+                         'interval (0 disables). Prefer --keepalive.')
     args = ap.parse_args()
+
+    if args.ws_keepalive is not None:
+        if args.ws_keepalive > 0:
+            args.keepalive = 'ws'
+            args.keepalive_interval = args.ws_keepalive
+        else:
+            args.keepalive = 'off'
 
     if not args.dc_ip:
         args.dc_ip = ['2:149.154.167.220', '4:149.154.167.220']
@@ -633,7 +655,8 @@ def main():
     proxy_config.cfproxy_worker_domains = coerce_domain_list(args.cfproxy_worker_domain)
     proxy_config.fake_tls_domain = args.fake_tls_domain.strip()
     proxy_config.proxy_protocol = args.proxy_protocol
-    proxy_config.ws_keepalive_interval = max(0, args.ws_keepalive)
+    proxy_config.keepalive_mode = args.keepalive
+    proxy_config.keepalive_interval = max(1.0, args.keepalive_interval)
 
     log_level = logging.DEBUG if args.verbose else logging.INFO
     log_fmt = logging.Formatter('%(asctime)s  %(levelname)-5s  %(message)s',

--- a/ui/ctk_tray_ui.py
+++ b/ui/ctk_tray_ui.py
@@ -50,6 +50,18 @@ _TIP_POOL = (
 _TIP_LOG_MB = (
     "Максимальный размер файла лога; при достижении лимита файл перезаписывается"
 )
+_TIP_KEEPALIVE = (
+    "Держит соединение с Telegram «тёплым», чтобы NAT/файрвол не рвал "
+    "простаивающие сессии.\n"
+    "TCP — на уровне ОС, незаметно для Telegram (рекомендуется).\n"
+    "WebSocket — старый режим через PING-кадры; часть серверов Telegram "
+    "из-за него рвёт соединение.\n"
+    "Выключен — keepalive не используется."
+)
+_TIP_KEEPALIVE_INTERVAL = (
+    "Интервал keepalive в секундах.\n"
+    "Для TCP — время простоя до проб, для WebSocket — период между PING"
+)
 _TIP_AUTOSTART = (
     "Запускать TG WS Proxy при входе в Windows. "
     "Если вы переместите программу в другую папку, автозапуск сбросится"
@@ -270,6 +282,14 @@ _APPEARANCE_FROM_CFG = {"auto": "Авто", "light": "Светлая", "dark": "
 _APPEARANCE_TO_CFG = {"Авто": "auto", "Светлая": "light", "Тёмная": "dark"}
 _APPEARANCE_TO_CTK = {"auto": "system", "light": "Light", "dark": "Dark"}
 
+_KEEPALIVE_OPTIONS = ["Выключен", "TCP (рекомендуется)", "WebSocket"]
+_KEEPALIVE_FROM_CFG = {
+    "off": "Выключен", "tcp": "TCP (рекомендуется)", "ws": "WebSocket",
+}
+_KEEPALIVE_TO_CFG = {
+    "Выключен": "off", "TCP (рекомендуется)": "tcp", "WebSocket": "ws",
+}
+
 
 def _entry(ctk, parent, theme, *, var=None, width=0, height=36, radius=10, **kw):
     opts = dict(
@@ -374,6 +394,8 @@ class TrayConfigFormWidgets:
     cfproxy_user_domain_var: Optional[Any] = None
     cfproxy_worker_domain_var: Optional[Any] = None
     appearance_var: Optional[Any] = None
+    keepalive_mode_var: Optional[Any] = None
+    keepalive_interval_var: Optional[Any] = None
 
 
 def install_tray_config_form(
@@ -706,6 +728,46 @@ def install_tray_config_form(
     adv_entries = list(adv_frame.winfo_children())
     adv_keys = ("buf_kb", "pool_size", "log_max_mb")
 
+    ka_frame = ctk.CTkFrame(log_inner, fg_color="transparent")
+    ka_frame.pack(fill="x", pady=(8, 0))
+    ka_l = _label(ctk, ka_frame, theme, "Keepalive соединений", size=11)
+    ka_l.pack(anchor="w", pady=(0, 2))
+    keepalive_mode_var = ctk.StringVar(
+        value=_KEEPALIVE_FROM_CFG.get(
+            str(cfg.get("keepalive_mode",
+                        default_config.get("keepalive_mode", "tcp"))).lower(),
+            "TCP (рекомендуется)")
+    )
+    ka_combo = ctk.CTkComboBox(
+        ka_frame, values=_KEEPALIVE_OPTIONS, variable=keepalive_mode_var,
+        width=_INNER_W, height=32, font=(theme.ui_font_family, 12),
+        text_color=theme.text_primary, fg_color=theme.field_bg,
+        border_color=theme.field_border, button_color=theme.field_border,
+        button_hover_color=theme.text_secondary,
+        dropdown_fg_color=theme.field_bg, dropdown_text_color=theme.text_primary,
+        dropdown_hover_color=theme.field_border, corner_radius=8,
+        state="readonly",
+    )
+    ka_combo.pack(fill="x")
+    attach_tooltip_to_widgets([ka_l, ka_combo, ka_frame], _TIP_KEEPALIVE)
+
+    ka_int_col = ctk.CTkFrame(log_inner, fg_color="transparent")
+    ka_int_col.pack(fill="x", pady=(5, 0))
+    ka_int_l = _label(ctk, ka_int_col, theme,
+                      "Keepalive: интервал, сек (по умолчанию 30)", size=11)
+    ka_int_l.pack(anchor="w", pady=(0, 2))
+    keepalive_interval_var = ctk.StringVar(
+        value=str(cfg.get("keepalive_interval",
+                          default_config.get("keepalive_interval", 30)))
+    )
+    ka_int_e = _entry(
+        ctk, ka_int_col, theme, width=_INNER_W, height=32, radius=8,
+        textvariable=keepalive_interval_var,
+    )
+    ka_int_e.pack(fill="x")
+    attach_tooltip_to_widgets([ka_int_l, ka_int_e, ka_int_col],
+                              _TIP_KEEPALIVE_INTERVAL)
+
     upd_inner = _config_section(ctk, frame, theme, "Обновления")
     st = get_status()
     check_updates_var = ctk.BooleanVar(
@@ -768,6 +830,8 @@ def install_tray_config_form(
         cfproxy_user_domain_var=cfproxy_user_domain_var,
         cfproxy_worker_domain_var=cfproxy_worker_domain_var,
         appearance_var=appearance_var,
+        keepalive_mode_var=keepalive_mode_var,
+        keepalive_interval_var=keepalive_interval_var,
     )
 
 
@@ -852,6 +916,16 @@ def validate_config_form(
         new_cfg["cfproxy_worker_domain"] = coerce_domain_list(widgets.cfproxy_worker_domain_var.get())
     if widgets.appearance_var is not None:
         new_cfg["appearance"] = _APPEARANCE_TO_CFG.get(widgets.appearance_var.get(), "auto")
+    if widgets.keepalive_mode_var is not None:
+        new_cfg["keepalive_mode"] = _KEEPALIVE_TO_CFG.get(
+            widgets.keepalive_mode_var.get(), "tcp")
+    if widgets.keepalive_interval_var is not None:
+        try:
+            new_cfg["keepalive_interval"] = max(
+                1.0, float(widgets.keepalive_interval_var.get().strip()))
+        except (ValueError, AttributeError):
+            new_cfg["keepalive_interval"] = default_config.get(
+                "keepalive_interval", 30)
     return new_cfg
 
 

--- a/utils/default_config.py
+++ b/utils/default_config.py
@@ -20,7 +20,8 @@ _TRAY_DEFAULTS_COMMON: Dict[str, Any] = {
     "cfproxy": True,
     "cfproxy_user_domain": [],
     "cfproxy_worker_domain": [],
-    "ws_keepalive_interval": 30
+    "keepalive_mode": "tcp",
+    "keepalive_interval": 30
 }
 
 

--- a/utils/tray_common.py
+++ b/utils/tray_common.py
@@ -180,12 +180,34 @@ def release_lock() -> None:
 
 # config
 
+_KEEPALIVE_MODES = ("off", "tcp", "ws")
+
+
+def _migrate_keepalive_keys(data: dict) -> None:
+    """Map the legacy ``ws_keepalive_interval`` key onto the mode model (-> tcp)."""
+    if "keepalive_mode" in data:
+        return
+    legacy = data.pop("ws_keepalive_interval", None)
+    if legacy is None:
+        return
+    try:
+        legacy = float(legacy)
+    except (TypeError, ValueError):
+        legacy = 0
+    if legacy > 0:
+        data["keepalive_mode"] = "tcp"
+        data["keepalive_interval"] = legacy
+    else:
+        data["keepalive_mode"] = "off"
+
+
 def load_config() -> dict:
     ensure_dirs()
     if CONFIG_FILE.exists():
         try:
             with open(CONFIG_FILE, "r", encoding="utf-8") as f:
                 data = json.load(f)
+            _migrate_keepalive_keys(data)
             for k, v in DEFAULT_CONFIG.items():
                 data.setdefault(k, v)
             return data
@@ -324,7 +346,16 @@ def apply_proxy_config(cfg: dict) -> bool:
     pc.fallback_cfproxy = cfg.get("cfproxy", DEFAULT_CONFIG["cfproxy"])
     pc.cfproxy_user_domains = coerce_domain_list(cfg.get("cfproxy_user_domain", DEFAULT_CONFIG["cfproxy_user_domain"]))
     pc.cfproxy_worker_domains = coerce_domain_list(cfg.get("cfproxy_worker_domain", DEFAULT_CONFIG["cfproxy_worker_domain"]))
-    pc.ws_keepalive_interval = max(0, cfg.get("ws_keepalive_interval", DEFAULT_CONFIG["ws_keepalive_interval"]))
+
+    mode = str(cfg.get("keepalive_mode", DEFAULT_CONFIG["keepalive_mode"])).lower()
+    if mode not in _KEEPALIVE_MODES:
+        mode = DEFAULT_CONFIG["keepalive_mode"]
+    pc.keepalive_mode = mode
+    try:
+        interval = float(cfg.get("keepalive_interval", DEFAULT_CONFIG["keepalive_interval"]))
+    except (TypeError, ValueError):
+        interval = float(DEFAULT_CONFIG["keepalive_interval"])
+    pc.keepalive_interval = max(1.0, interval)
     return True
 
 


### PR DESCRIPTION
## Проблема

Keepalive, добавленный в #925 (issue #646), отправлял WebSocket-PING фреймы
в апстрим Telegram (`/apiws`). Этот шлюз не принимает клиентские control-PING
и закрывает соединение при их получении. В результате keepalive, задуманный
чтобы *держать* соединения живыми, наоборот рубил их ровно на интервале.

Подпись бага в логах: сессии закрывались строго на `in 30.1s` (= интервал),
причём отсчёт шёл от открытия каждой сессии, а не от последней активности -
рвались даже активные загрузки.

Связано с #1023.

## Причина

`_ws_keepalive` слал `OP_PING` (0x9) в апстрим раз в `ws_keepalive_interval`
секунд. Для `/apiws` это нарушение протокола -> сервер присылает CLOSE ->
сессия закрывается. Официальный веб-клиент Telegram WS-пинги не использует
(шлёт MTProto-пинги внутри бинарного потока).

## Решение

Keepalive теперь выбирается режимом (настройка + CLI):

- **`tcp`** (по умолчанию) - OS-level `SO_KEEPALIVE` на апстрим-сокете.
  Пробы живут под TLS, невидимы для прикладного слоя Telegram, держат
  NAT/firewall тёплыми (цель #646) и не триггерят разрыв.
- **`ws`** - прежний WebSocket-PING (legacy; ломается на `/apiws`).
- **`off`** - keepalive выключен.

Кросс-платформенно: Windows - `SIO_KEEPALIVE_VALS`, Linux -
`TCP_KEEPIDLE/INTVL/CNT`, macOS - `TCP_KEEPALIVE`.

### Обратная совместимость

Старый ключ `ws_keepalive_interval` мигрируется при загрузке конфига:
`interval > 0` -> `tcp` (безопасный режим) с сохранением интервала,
`interval <= 0` -> `off`. Существующим пользователям ничего перенастраивать
не нужно - их «вредный» конфиг тихо станет безопасным TCP.

## Изменения

- `proxy/config.py` - `keepalive_mode` / `keepalive_interval`
- `proxy/raw_websocket.py` - `_enable_tcp_keepalive`, включается только на апстриме
- `proxy/bridge.py` - WS-PING только в режиме `ws`
- `proxy/tg_ws_proxy.py` - `--ws-keepalive-mode`, баннер `Keepalive: …`
- `utils/tray_common.py` - миграция ключа + `apply_proxy_config`
- `utils/default_config.py` - дефолт `tcp` / 30s
- `ui/ctk_tray_ui.py` - селектор режима + поле интервала
