### PR TITLE
Add Docker image build to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,6 +343,43 @@ jobs:
           name: TgWsProxy-macOS
           path: dist/TgWsProxy_macos_universal.dmg
 
+  build-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   build-linux:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Changes

Added a new `build-docker` job to the CI/CD pipeline that builds and pushes multi-arch (amd64/arm64) Docker images to GHCR.

### What it does

- Builds Docker images for both `linux/amd64` and `linux/arm64` platforms
- Pushes to `ghcr.io/marker689/tg-ws-proxy` with semantic versioning tags
- Uses `docker/metadata-action` for proper tag management (latest, sha, semver)
- Uses `docker/setup-qemu-action` for multi-arch support

### Why

The original Dockerfile already supports containerized deployment but there's no automated build/push pipeline. This allows users to pull pre-built images without building locally.

### Workflow usage

- **With release**: Triggers alongside the existing build jobs when `make_release` is enabled
- **Without release**: Can be triggered standalone via `workflow_dispatch` to just build/push Docker images
