### PR TITLE
fixed pool.py

### DIFF
--- a/proxy/pool.py
+++ b/proxy/pool.py
@@ -22,7 +22,8 @@ class _WsPool:
         self.fronting_until: float = 0.0
 
     async def get(self, dc: int, is_media: bool,
-                  target_ip: str, domains: List[str]
+                  target_ip: str, domains: List[str],
+                  path=None
                   ) -> Optional[RawWebSocket]:
         key = (dc, is_media)
         now = time.monotonic()


### PR DESCRIPTION
After installing and starting the app following the [docker guide](https://github.com/Flowseal/tg-ws-proxy/blob/main/docs/README.docker.md), the container crashes with the following error:
```python
19:49:50  INFO   [172.17.0.1:50798] DC3 -> trying CF proxy
19:49:50  ERROR  [172.17.0.1:50792] unexpected: _WsPool.get() got an unexpected keyword argument 'path'
Traceback (most recent call last):
  File "/app/proxy/tg_ws_proxy.py", line 347, in _handle_client
    ws = await ws_pool.get(dc, is_media, target, domains, path=ws_path) if not is_test_dc else None
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _WsPool.get() got an unexpected keyword argument 'path'
19:49:50  ERROR  [172.17.0.1:50804] unexpected: _WsPool.get() got an unexpected keyword argument 'path'
Traceback (most recent call last):
  File "/app/proxy/tg_ws_proxy.py", line 347, in _handle_client
    ws = await ws_pool.get(dc, is_media, target, domains, path=ws_path) if not is_test_dc else None
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _WsPool.get() got an unexpected keyword argument 'path'
19:49:50  ERROR  [172.17.0.1:50816] unexpected: _WsPool.get() got an unexpected keyword argument 'path'
Traceback (most recent call last):
  File "/app/proxy/tg_ws_proxy.py", line 347, in _handle_client
    ws = await ws_pool.get(dc, is_media, target, domains, path=ws_path) if not is_test_dc else None
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _WsPool.get() got an unexpected keyword argument 'path'
19:49:51  ERROR  [172.17.0.1:50828] unexpected: _WsPool.get() got an unexpected keyword argument 'path'
Traceback (most recent call last):
  File "/app/proxy/tg_ws_proxy.py", line 347, in _handle_client
    ws = await ws_pool.get(dc, is_media, target, domains, path=ws_path) if not is_test_dc else None
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _WsPool.get() got an unexpected keyword argument 'path'
19:49:51  INFO   [172.17.0.1:50798] DC3 WS session closed (normal): ^539.0B (3 pkts) v899.0B (4 pkts) in 0.6s
19:49:53  ERROR  [172.17.0.1:50844] unexpected: _WsPool.get() got an unexpected keyword argument 'path'
Traceback (most recent call last):
  File "/app/proxy/tg_ws_proxy.py", line 347, in _handle_client
    ws = await ws_pool.get(dc, is_media, target, domains, path=ws_path) if not is_test_dc else None
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _WsPool.get() got an unexpected keyword argument 'path'
```

This pr brings back the "forgotten" path function argument, after which the app works as expected.