### PR TITLE
Исправление сборки Docker-образа

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-RUN "$VIRTUAL_ENV/bin/pip" install cryptography==46.0.5
+RUN "$VIRTUAL_ENV/bin/pip" install cryptography==46.0.5 certifi
 
 FROM python:3.12-slim AS runtime
 


### PR DESCRIPTION
В процесс сборки добавлен пакет certifi, отсутствие которого вызывало ошибку после коммита 9f9e1c2.