### PR TITLE
Исправил ошибки в настройках, обновлении и остановке прокси

### DIFF
--- a/proxy/raw_websocket.py
+++ b/proxy/raw_websocket.py
@@ -212,15 +212,14 @@ class RawWebSocket:
         return None
 
     async def close(self):
-        if self._closed:
-            return
-        self._closed = True
-        try:
-            self.writer.write(
-                self._build_frame(self.OP_CLOSE, b'', mask=True))
-            await self.writer.drain()
-        except Exception:
-            pass
+        if not self._closed:
+            self._closed = True
+            try:
+                self.writer.write(
+                    self._build_frame(self.OP_CLOSE, b'', mask=True))
+                await self.writer.drain()
+            except Exception:
+                pass
         try:
             self.writer.close()
             await self.writer.wait_closed()

--- a/proxy/tg_ws_proxy.py
+++ b/proxy/tg_ws_proxy.py
@@ -702,7 +702,8 @@ def main():
             log.error("Secret must be exactly 32 hex characters")
             sys.exit(1)
         try:
-            bytes.fromhex(secret_hex)
+            if len(bytes.fromhex(secret_hex)) != 16:
+                raise ValueError
         except ValueError:
             log.error("Secret must be valid hex")
             sys.exit(1)

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,0 +1,14 @@
+import unittest
+from unittest.mock import patch
+
+from proxy import tg_ws_proxy as proxy
+
+
+class CliSecretTest(unittest.TestCase):
+    def test_secret_with_internal_spaces_exits_before_starting(self):
+        with patch('sys.argv', ['proxy', '--secret', 'aa ' * 10 + 'aa']):
+            with patch.object(proxy.asyncio, 'run') as run:
+                with self.assertRaises(SystemExit) as caught:
+                    proxy.main()
+                self.assertEqual(caught.exception.code, 1)
+                run.assert_not_called()

--- a/tests/test_proxy_lifecycle.py
+++ b/tests/test_proxy_lifecycle.py
@@ -1,0 +1,83 @@
+import asyncio
+import threading
+import unittest
+from unittest.mock import patch
+
+from utils import tray_common as tray
+
+
+class ProxyLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.cfg = dict(tray.DEFAULT_CONFIG, pool_size=0, cfproxy=False)
+        self.addCleanup(tray.stop_proxy)
+
+    def test_stop_during_loop_initialization_waits_for_worker(self):
+        entered = threading.Event()
+        release = threading.Event()
+        make_loop = asyncio.new_event_loop
+
+        def delayed_loop():
+            entered.set()
+            if not release.wait(2):
+                raise TimeoutError('test did not release worker')
+            return make_loop()
+
+        async def run(stop_event):
+            await stop_event.wait()
+
+        with patch.object(tray.asyncio, 'new_event_loop', delayed_loop), patch.object(tray, '_run', run):
+            tray.start_proxy(self.cfg, self.fail)
+            worker = tray._proxy_thread
+            self.assertTrue(entered.wait(1))
+            timer = threading.Timer(0.05, release.set)
+            timer.start()
+            try:
+                tray.stop_proxy()
+                self.assertFalse(worker.is_alive())
+                self.assertIsNone(tray._proxy_thread)
+            finally:
+                release.set()
+                timer.join()
+
+    def test_repeated_start_stop_clears_stop_request(self):
+        started = threading.Event()
+
+        async def run(stop_event):
+            self.assertFalse(stop_event.is_set())
+            started.set()
+            await stop_event.wait()
+
+        with patch.object(tray, '_run', run):
+            for _ in range(3):
+                started.clear()
+                tray.start_proxy(self.cfg, self.fail)
+                self.assertTrue(started.wait(1))
+                worker = tray._proxy_thread
+                tray.start_proxy(self.cfg, self.fail)
+                self.assertIs(tray._proxy_thread, worker)
+                tray.stop_proxy()
+                self.assertFalse(worker.is_alive())
+
+    def test_timed_out_worker_is_kept_and_cannot_be_replaced(self):
+        started = threading.Event()
+        release = threading.Event()
+
+        async def run(stop_event):
+            started.set()
+            await asyncio.get_running_loop().run_in_executor(None, release.wait)
+
+        with patch.object(tray, '_run', run):
+            tray.start_proxy(self.cfg, self.fail)
+            self.assertTrue(started.wait(1))
+            worker = tray._proxy_thread
+            try:
+                with patch.object(worker, 'join'):
+                    tray.stop_proxy()
+                self.assertIs(tray._proxy_thread, worker)
+                tray.start_proxy(self.cfg, self.fail)
+                self.assertIs(tray._proxy_thread, worker)
+            finally:
+                release.set()
+                worker.join(2)
+            tray.stop_proxy()
+            self.assertIsNone(tray._proxy_thread)

--- a/tests/test_raw_websocket.py
+++ b/tests/test_raw_websocket.py
@@ -108,6 +108,51 @@ class RecvTest(unittest.TestCase):
             ], cls=_Capped)
 
 
+class CloseTest(unittest.IsolatedAsyncioTestCase):
+    async def check_close(self, remote_close):
+        eof = asyncio.Event()
+        writers = []
+        tasks = []
+
+        async def peer(reader, writer):
+            writers.append(writer)
+            tasks.append(asyncio.current_task())
+            if remote_close:
+                writer.write(_raw_frame(RawWebSocket.OP_CLOSE, b'\x03\xe8'))
+                await writer.drain()
+            while await reader.read(1024):
+                pass
+            eof.set()
+
+        server = await asyncio.start_server(peer, '127.0.0.1', 0)
+        reader, writer = await asyncio.open_connection(
+            '127.0.0.1', server.sockets[0].getsockname()[1])
+        ws = RawWebSocket(reader, writer)
+        try:
+            if remote_close:
+                self.assertIsNone(await ws.recv())
+            await ws.close()
+            self.assertTrue(writer.is_closing())
+            await asyncio.wait_for(eof.wait(), 1)
+            await ws.close()
+            self.assertTrue(writer.is_closing())
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            for peer_writer in writers:
+                peer_writer.close()
+                await peer_writer.wait_closed()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            server.close()
+            await server.wait_closed()
+
+    async def test_peer_close_then_cleanup_closes_transport(self):
+        await self.check_close(remote_close=True)
+
+    async def test_local_close_and_repeated_cleanup_close_transport(self):
+        await self.check_close(remote_close=False)
+
+
 class ParseCloseTest(unittest.TestCase):
     def test_known_code_gets_name(self):
         code, reason = RawWebSocket._parse_close(b'\x03\xe8bye')

--- a/tests/test_tray_form.py
+++ b/tests/test_tray_form.py
@@ -1,0 +1,107 @@
+import math
+import unittest
+from copy import deepcopy
+from types import SimpleNamespace
+
+try:
+    from ui.ctk_tray_ui import merge_adv_from_form
+except ImportError:
+    merge_adv_from_form = None
+
+
+@unittest.skipIf(merge_adv_from_form is None, 'Tk is required to import the settings form')
+class AdvancedFormTest(unittest.TestCase):
+    def merge(self, key, value):
+        entry = SimpleNamespace(get=lambda: value)
+        frame = SimpleNamespace(winfo_children=lambda: [None, entry])
+        widgets = SimpleNamespace(adv_keys=(key,), adv_entries=[frame])
+        result = {}
+        merge_adv_from_form(widgets, result, {'buf_kb': 256, 'pool_size': 4, 'log_max_mb': 5})
+        return result[key]
+
+    def test_non_finite_values_use_defaults(self):
+        for key, default in (('buf_kb', 256), ('pool_size', 4), ('log_max_mb', 5)):
+            for value in ('nan', 'NaN', 'inf', '-inf', '1e309', '-1e309', 'abc', ''):
+                with self.subTest(key=key, value=value):
+                    self.assertEqual(self.merge(key, value), default)
+
+    def test_log_size_that_overflows_bytes_uses_default(self):
+        self.assertEqual(self.merge('log_max_mb', '1e308'), 5)
+
+    def test_valid_values_keep_existing_conversion(self):
+        self.assertEqual(self.merge('buf_kb', '512'), 512)
+        self.assertEqual(self.merge('pool_size', '0'), 0)
+        self.assertEqual(self.merge('pool_size', '4.9'), 4)
+        self.assertEqual(self.merge('log_max_mb', '2.5'), 2.5)
+        self.assertTrue(math.isfinite(self.merge('log_max_mb', 'nan')))
+
+
+@unittest.skipIf(merge_adv_from_form is None, 'Tk is required to import the settings form')
+class SecretValidationTest(unittest.TestCase):
+    def test_requires_16_decoded_bytes_without_internal_whitespace(self):
+        from ui.ctk_tray_ui import TrayConfigFormWidgets, validate_config_form
+        from utils.default_config import default_tray_config
+
+        def var(value):
+            return SimpleNamespace(get=lambda *args: value)
+
+        for secret, valid in [('a' * 32, True), ('A' * 32, True),
+                              ('z' * 32, False), ('a' * 31, False),
+                              ('aa ' * 10 + 'aa', False)]:
+            with self.subTest(secret=secret):
+                form = TrayConfigFormWidgets(
+                    host_var=var('127.0.0.1'), port_var=var('1443'),
+                    secret_var=var(secret), dc_textbox=var('2:149.154.167.220'),
+                    verbose_var=var(False), adv_keys=(), adv_entries=[],
+                    autostart_var=None, check_updates_var=None,
+                )
+                result = validate_config_form(form, default_tray_config(), include_autostart=False)
+                self.assertEqual(isinstance(result, dict), valid)
+
+
+class ThemePreviewTest(unittest.TestCase):
+    def test_theme_preview_preserves_config_snapshot_and_validates_selection(self):
+        try:
+            import tkinter
+            import customtkinter as ctk
+        except ImportError:
+            self.skipTest('Tk and customtkinter are required for the GUI regression')
+        from ui.ctk_theme import ctk_theme_for_platform
+        from ui.ctk_tray_ui import install_tray_config_form, validate_config_form
+        from ui.i18n import get_language, set_language, t
+        from utils.default_config import default_tray_config
+
+        previous_language = get_language()
+        previous_appearance = ctk.get_appearance_mode()
+        try:
+            root = ctk.CTk()
+        except tkinter.TclError as exc:
+            self.skipTest(f'Tk display unavailable: {exc}')
+        root.withdraw()
+        try:
+            cfg = dict(default_tray_config(), appearance='light', language='ru')
+            snapshot = deepcopy(cfg)
+            form = install_tray_config_form(ctk, root, ctk_theme_for_platform(), cfg, cfg)
+
+            def find_theme(widget):
+                if isinstance(widget, ctk.CTkComboBox) and t('appearance.dark') in widget.cget('values'):
+                    return widget
+                for child in widget.winfo_children():
+                    found = find_theme(child)
+                    if found is not None:
+                        return found
+                return None
+
+            combo = find_theme(root)
+            self.assertIsNotNone(combo)
+            combo.set(t('appearance.dark'))
+            combo.cget('command')(t('appearance.dark'))
+            self.assertEqual(ctk.get_appearance_mode(), 'Dark')
+            self.assertEqual(cfg, snapshot)
+            merged = validate_config_form(form, cfg, include_autostart=False)
+            self.assertIsInstance(merged, dict)
+            self.assertEqual(merged['appearance'], 'dark')
+        finally:
+            root.destroy()
+            ctk.set_appearance_mode(previous_appearance)
+            set_language(previous_language)

--- a/tests/test_windows_update.py
+++ b/tests/test_windows_update.py
@@ -1,0 +1,137 @@
+import sys
+import tempfile
+import threading
+import unittest
+from contextlib import ExitStack
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+@unittest.skipUnless(sys.platform == 'win32', 'Windows updater')
+class WindowsUpdateTest(unittest.TestCase):
+    def setUp(self):
+        import windows
+        self.windows = windows
+        self.stack = ExitStack()
+        self.addCleanup(self.stack.close)
+        directory = self.stack.enter_context(tempfile.TemporaryDirectory())
+        self.exe = Path(directory) / 'TgWsProxy.exe'
+        self.original = b'original test executable - never executed'
+        self.exe.write_bytes(self.original)
+        self.stack.enter_context(patch.object(windows.sys, 'executable', str(self.exe)))
+        self.stack.enter_context(patch.object(windows.time, 'sleep'))
+        self.stop = self.stack.enter_context(patch.object(windows, 'stop_proxy'))
+        self.release = self.stack.enter_context(patch.object(windows, '_release_win_mutex'))
+        self.launch = self.stack.enter_context(patch.object(windows.subprocess, 'Popen'))
+        self.exit = self.stack.enter_context(patch.object(windows.os, '_exit'))
+        self.messages = []
+
+    def assert_original_kept(self):
+        self.assertEqual(self.exe.read_bytes(), self.original)
+        self.assertEqual(list(self.exe.parent.glob('*.tmp')), [])
+        self.stop.assert_not_called()
+        self.release.assert_not_called()
+        self.launch.assert_not_called()
+        self.exit.assert_not_called()
+
+    def run_http_download(self, body, length):
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                if length is not None:
+                    self.send_header('Content-Length', str(length))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                pass
+
+        server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            self.windows._perform_update(
+                f'http://127.0.0.1:{server.server_port}/update', self.messages.append,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+    def test_truncated_http_download_keeps_original(self):
+        self.run_http_download(b'MZpartial', 1024)
+        self.assert_original_kept()
+        self.assertIn('1024', self.messages[-1])
+
+    def test_empty_download_keeps_original(self):
+        self.run_http_download(b'', 0)
+        self.assert_original_kept()
+
+    def test_invalid_content_length_keeps_original(self):
+        self.run_http_download(b'MZpartial', 'invalid')
+        self.assert_original_kept()
+
+    def test_empty_download_without_length_keeps_original(self):
+        self.run_http_download(b'', None)
+        self.assert_original_kept()
+
+    def test_rename_denied_keeps_original(self):
+        with patch.object(Path, 'rename', side_effect=PermissionError('test rename denied')):
+            self.run_http_download(b'MZupdate', 8)
+        self.assert_original_kept()
+
+    def test_install_failure_restores_original(self):
+        rename = Path.rename
+
+        def fail_install(source, target):
+            if source.suffix == '.tmp':
+                raise PermissionError('test install denied')
+            return rename(source, target)
+
+        with patch.object(Path, 'rename', fail_install):
+            self.run_http_download(b'MZupdate', 8)
+        self.assert_original_kept()
+
+    def test_complete_download_replaces_and_restarts(self):
+        payload = b'MZsynthetic update'
+        self.run_http_download(payload, len(payload))
+        self.assertEqual(self.exe.read_bytes(), payload)
+        self.assertEqual(self.exe.with_name('TgWsProxy_oldtgws.exe').read_bytes(), self.original)
+        self.launch.assert_called_once()
+        self.exit.assert_called_once_with(0)
+
+    def test_nonempty_download_without_length_still_works(self):
+        payload = b'MZsynthetic update without content length'
+        self.run_http_download(payload, None)
+        self.assertEqual(self.exe.read_bytes(), payload)
+        self.launch.assert_called_once()
+
+    def test_timeout_keeps_original_and_is_bounded(self):
+        opener = Mock()
+        opener.open.side_effect = TimeoutError('test stalled download')
+        with patch.object(self.windows, 'build_github_opener', return_value=opener):
+            self.windows._perform_update('https://example.invalid/update', self.messages.append)
+        timeout = opener.open.call_args.kwargs.get('timeout')
+        self.assertIsNotNone(timeout)
+        self.assertGreater(timeout, 0)
+        self.assertLessEqual(timeout, 60)
+        self.assert_original_kept()
+
+    def test_read_error_keeps_original(self):
+        response = Mock()
+        response.headers = {'Content-Length': '1024'}
+        response.read.side_effect = [b'MZpartial', TimeoutError('test read timeout')]
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=False)
+        opener = Mock()
+        opener.open.return_value = response
+        with patch.object(self.windows, 'build_github_opener', return_value=opener):
+            self.windows._perform_update('https://example.invalid/update', self.messages.append)
+        self.assert_original_kept()
+
+    def test_unwritable_directory_reports_error_without_stopping(self):
+        with patch.object(self.windows.tempfile, 'mkstemp', side_effect=PermissionError('test denied')):
+            self.windows._perform_update('https://example.invalid/update', self.messages.append)
+        self.assert_original_kept()
+        self.assertIn('test denied', self.messages[-1])

--- a/ui/ctk_tray_ui.py
+++ b/ui/ctk_tray_ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import webbrowser
 from dataclasses import dataclass
@@ -398,7 +399,6 @@ def install_tray_config_form(
     def _on_appearance_change(choice: str) -> None:
         cfg_val = _appearance_to_cfg(choice)
         ctk.set_appearance_mode(_APPEARANCE_TO_CTK[cfg_val])
-        cfg["appearance"] = cfg_val
 
     ctk.CTkButton(
         header, text="Donate ♥", width=90, height=28,
@@ -846,6 +846,10 @@ def merge_adv_from_form(
         entry = col_frame.winfo_children()[1]
         try:
             val = float(entry.get().strip())
+            if not math.isfinite(val):
+                raise ValueError
+            if key == "log_max_mb" and not math.isfinite(val * 1024 * 1024):
+                raise ValueError
             if key in ("buf_kb", "pool_size"):
                 val = int(val)
             base[key] = val
@@ -898,7 +902,8 @@ def validate_config_form(
     if len(secret_val) != 32:
         return t("validation.bad_secret_len")
     try:
-        bytes.fromhex(secret_val)
+        if len(bytes.fromhex(secret_val)) != 16:
+            raise ValueError
     except ValueError:
         return t("validation.bad_secret_hex")
 

--- a/utils/tray_common.py
+++ b/utils/tray_common.py
@@ -306,6 +306,8 @@ def load_icon():
 
 _proxy_thread: Optional[threading.Thread] = None
 _async_stop: Optional[Tuple[asyncio.AbstractEventLoop, asyncio.Event]] = None
+_proxy_stop_requested = threading.Event()
+_proxy_lifecycle_lock = threading.RLock()
 
 
 def _run_proxy_thread(show_error: Callable[[str], None]) -> None:
@@ -315,6 +317,8 @@ def _run_proxy_thread(show_error: Callable[[str], None]) -> None:
     asyncio.set_event_loop(loop)
     stop_ev = asyncio.Event()
     _async_stop = (loop, stop_ev)
+    if _proxy_stop_requested.is_set():
+        stop_ev.set()
 
     try:
         loop.run_until_complete(_run(stop_event=stop_ev))
@@ -379,42 +383,51 @@ def apply_proxy_config(cfg: dict) -> bool:
 
 def start_proxy(cfg: dict, on_error: Callable[[str], None]) -> None:
     global _proxy_thread
-    if _proxy_thread and _proxy_thread.is_alive():
-        log.info("Proxy already running")
-        return
+    with _proxy_lifecycle_lock:
+        if _proxy_thread and _proxy_thread.is_alive():
+            log.info("Proxy already running")
+            return
 
-    if not apply_proxy_config(cfg):
-        from ui.i18n import t
-        on_error(t("error.dc_config"))
-        return
+        if not apply_proxy_config(cfg):
+            from ui.i18n import t
+            on_error(t("error.dc_config"))
+            return
 
-    pc = proxy_config
-    log.info("Starting proxy on %s:%d ...", pc.host, pc.port)
-    _proxy_thread = threading.Thread(
-        target=_run_proxy_thread, args=(on_error,), daemon=True, name="proxy"
-    )
-    _proxy_thread.start()
+        pc = proxy_config
+        log.info("Starting proxy on %s:%d ...", pc.host, pc.port)
+        _proxy_stop_requested.clear()
+        _proxy_thread = threading.Thread(
+            target=_run_proxy_thread, args=(on_error,), daemon=True, name="proxy"
+        )
+        _proxy_thread.start()
 
 
 def stop_proxy() -> None:
     global _proxy_thread, _async_stop
-    if _async_stop:
-        loop, stop_ev = _async_stop
-        loop.call_soon_threadsafe(stop_ev.set)
+    with _proxy_lifecycle_lock:
+        _proxy_stop_requested.set()
+        if _async_stop:
+            loop, stop_ev = _async_stop
+            try:
+                loop.call_soon_threadsafe(stop_ev.set)
+            except RuntimeError:
+                pass  # The worker may have closed its loop after failing.
         if _proxy_thread:
             _proxy_thread.join(timeout=5)
             if _proxy_thread.is_alive():
                 log.warning("Proxy thread did not stop within timeout; "
                             "port may still be in use")
-    _proxy_thread = None
-    log.info("Proxy stopped")
+                return
+        _proxy_thread = None
+        log.info("Proxy stopped")
 
 
 def restart_proxy(cfg: dict, on_error: Callable[[str], None]) -> None:
-    log.info("Restarting proxy...")
-    stop_proxy()
-    time.sleep(1.0)
-    start_proxy(cfg, on_error)
+    with _proxy_lifecycle_lock:
+        log.info("Restarting proxy...")
+        stop_proxy()
+        time.sleep(1.0)
+        start_proxy(cfg, on_error)
 
 
 def tg_proxy_url(cfg: dict) -> str:

--- a/windows.py
+++ b/windows.py
@@ -252,13 +252,24 @@ def _perform_update(download_url: str, set_status=None) -> None:
         tmp_path = Path(tmp_name)
         log.info("Downloading update from %s", download_url)
         opener = build_github_opener()
-        with opener.open(download_url) as _resp:
+        with opener.open(download_url, timeout=30) as _resp:
+            content_length = _resp.headers.get("Content-Length")
+            expected_size = int(content_length) if content_length is not None else None
+            downloaded_size = 0
             with open(str(tmp_path), "wb") as _fout:
                 while True:
                     _chunk = _resp.read(65536)
                     if not _chunk:
                         break
                     _fout.write(_chunk)
+                    downloaded_size += len(_chunk)
+            if downloaded_size == 0:
+                raise OSError("Downloaded update is empty")
+            if expected_size is not None and downloaded_size != expected_size:
+                raise OSError(
+                    f"Incomplete update download: expected {expected_size} bytes, "
+                    f"received {downloaded_size}"
+                )
     except Exception as exc:
         _err(t("update.download_fail", error=exc))
         if tmp_path:


### PR DESCRIPTION
Проверял версию 1.10.2 на Windows и исправил несколько ошибок:

- Выбранная тема не сохранялась, если остальные настройки не трогать. Теперь сохраняется.
- `inf` и `1e309` в размере буфера или пула ломали сохранение настроек, а `nan` и `inf` в размере лога — следующий запуск. Для таких значений теперь используются настройки по умолчанию.
- Secret с пробелами мог пройти проверку длины, но оказаться короче нужных 16 байт. Такой ввод теперь отклоняется и в окне настроек, и в CLI.
- При обрыве загрузки обновления недокачанный файл заменял рабочий exe. Теперь пустой файл или несовпадение с `Content-Length` останавливают обновление до замены. Добавил таймаут сетевых операций.
- После закрытия WebSocket со стороны сервера TCP-соединение оставалось открытым. Исправил его закрытие.
- Если нажать «Стоп», пока прокси ещё запускается, он мог продолжить работать. Теперь этот случай обрабатывается; одновременные перезапуски идут по очереди, а новый поток не запускается, пока старый ещё работает.

Обрыв обновления можно воспроизвести сервером, который отвечает с `Content-Length: 1024`, передаёт несколько байт и закрывает соединение. После исправления рабочий exe остаётся на месте.